### PR TITLE
rm fixed dependency on ui-plugin-find-users 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix spelling of parameter to lookup-users. UIS-71.
 * Remove metadata property from JSON before PUTting settings. UICHKOUT-15.
 * Add Patron info. UICHKOUT-5.
-* Remove fixed dependency on plugin-find-users 1.0.0. Refs STRIPES-478. 
+* Remove fixed dependency on plugin-find-users 1.0.0. Refs STRIPES-478, Fixes UICHKOUT-18. 
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix spelling of parameter to lookup-users. UIS-71.
 * Remove metadata property from JSON before PUTting settings. UICHKOUT-15.
 * Add Patron info. UICHKOUT-5.
+* Remove fixed dependency on plugin-find-users 1.0.0. Refs STRIPES-478. 
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "eslint-plugin-react": "^6.4.1"
   },
   "dependencies": {
-    "@folio/plugin-find-user": "1.0.0",
     "@folio/stripes-components": "^1.7.0",
     "dateformat": "^2.0.0",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
Apps should not depend explicitly on plugins. The WHOLE POINT of a
plugin is that it can be switched out at runtime. Also, the fact that
this was a hard dep on version 1.0.0 rather than, say, ^1.0.0, appears
to have caused multiple copies of the plugin and of its dependencies to
be built into the bundle and that caused no end of trouble.