### PR TITLE
don't use react-bootstrap's Row, Col. Refs STRIPES-427

### DIFF
--- a/lib/ItemForm/ItemForm.js
+++ b/lib/ItemForm/ItemForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import Button from '@folio/stripes-components/lib/Button';
 import TextField from '@folio/stripes-components/lib/TextField';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 const propTypes = {
   handleSubmit: PropTypes.func.isRequired,

--- a/lib/PatronForm/PatronForm.js
+++ b/lib/PatronForm/PatronForm.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import TextField from '@folio/stripes-components/lib/TextField';
 import Button from '@folio/stripes-components/lib/Button';
-import { Row, Col } from 'react-bootstrap';
-
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import MaybeUserSearch from '../../MaybeUserSearch';
 
 const propTypes = {

--- a/lib/ProxyForm/ProxyForm.js
+++ b/lib/ProxyForm/ProxyForm.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import Button from '@folio/stripes-components/lib/Button';
 import RadioButton from '@folio/stripes-components/lib/RadioButton';
-import { Row, Col } from 'react-bootstrap';
-
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import { getFullName } from '../../util';
 
 const propTypes = {

--- a/lib/UserDetail/UserDetail.js
+++ b/lib/UserDetail/UserDetail.js
@@ -2,8 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from 'react-bootstrap';
-
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import { getFullName, formatDate } from '../../util';
 import css from './UserDetail.css';
 

--- a/lib/ViewPatron/ViewPatron.js
+++ b/lib/ViewPatron/ViewPatron.js
@@ -2,8 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import { Row, Col } from 'react-bootstrap';
-
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import ProxyModal from '../ProxyModal';
 import UserDetail from '../UserDetail';
 import css from './ViewPatron.css';

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.31.1",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3",
     "uuid": "^3.0.1"

--- a/settings/ScanCheckoutSettings.js
+++ b/settings/ScanCheckoutSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Pane from '@folio/stripes-components/lib/Pane';
 import Select from '@folio/stripes-components/lib/Select';
 


### PR DESCRIPTION
Old versions of react-bootstrap barf up the `Warning: Accessing PropTypes via the main React package is deprecated...` message. We could just upgrade, but are working to deprecate react-bootstrap anyway.