### PR TITLE
cast boolean-ish value to boolean. Refs UICHKOUT-42

### DIFF
--- a/lib/UserDetail/UserDetail.js
+++ b/lib/UserDetail/UserDetail.js
@@ -54,7 +54,7 @@ class UserDetail extends React.Component {
     const { user, resources, label, settings } = this.props;
     const patronGroups = (resources.patronGroups || {}).records || [];
     const patronGroup = patronGroups[0] || {};
-    const hasProfilePicture = (settings.length && settings[0].value === 'true');
+    const hasProfilePicture = !!(settings.length && settings[0].value === 'true');
 
     return (
       <div>


### PR DESCRIPTION
It turns out that in some contexts JSX will render falsy integer values
as integers and sometimes as booleans. `hasProfilePicture` is only used
in a boolean context here, so it is now casted to boolean.