### PR TITLE
Clearing modal in onCloseModal and passing it to props

### DIFF
--- a/lib/PatronForm/PatronForm.js
+++ b/lib/PatronForm/PatronForm.js
@@ -19,6 +19,7 @@ class PatronForm extends React.Component {
   constructor(props) {
     super(props);
     this.selectUser = this.selectUser.bind(this);
+    this.onCloseModal = this.onCloseModal.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -39,6 +40,14 @@ class PatronForm extends React.Component {
     } else {
       Object.assign(user, { error: `User ${user.username} does not have a ${userIdentifierPref.label}` });
     }
+  }
+
+  onCloseModal(modalProps) {
+    modalProps.parentMutator.query.update({
+      query: '',
+      filters: 'active.Active',
+      sort: 'Name',
+    });
   }
 
   render() {
@@ -69,6 +78,7 @@ class PatronForm extends React.Component {
               marginTop0
               searchButtonStyle="link"
               selectUser={this.selectUser}
+              onCloseModal={this.onCloseModal}
               visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
               disableRecordCreation={disableRecordCreation}
             />

--- a/lib/PatronForm/PatronForm.js
+++ b/lib/PatronForm/PatronForm.js
@@ -42,14 +42,6 @@ class PatronForm extends React.Component {
     }
   }
 
-  onCloseModal(modalProps) {
-    modalProps.parentMutator.query.update({
-      query: '',
-      filters: 'active.Active',
-      sort: 'Name',
-    });
-  }
-
   render() {
     const { userIdentifierPref, submitting, handleSubmit } = this.props;
     const validationEnabled = false;
@@ -78,7 +70,13 @@ class PatronForm extends React.Component {
               marginTop0
               searchButtonStyle="link"
               selectUser={this.selectUser}
-              onCloseModal={this.onCloseModal}
+              onCloseModal={(modalProps) => {
+                modalProps.parentMutator.query.update({
+                  query: '',
+                  filters: 'active.Active',
+                  sort: 'Name',
+                });
+              }}
               visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
               disableRecordCreation={disableRecordCreation}
             />


### PR DESCRIPTION
Resolves [UICHKOUT-46](https://issues.folio.org/browse/UICHKOUT-46):

This creates a method `onCloseModal` which clears the search modal, and passes it forward into the find user plugin. Depends on other PRs: [ui-plugin-find-user](https://github.com/folio-org/ui-plugin-find-user/pull/10), [ui-users](https://github.com/folio-org/ui-users/pull/221), [stripes-smart-components](https://github.com/folio-org/stripes-smart-components/pull/80)