### PR TITLE
save changes to Settings > Circ > Scan ID form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Get fixed loan period from loan policy. Fixes UICHKOUT-66.
 * Move checkout links into actions menu. Fixes UICHKOUT-74.
 * Make borrowing patron more prominent. Fixes UICHKOUT-47. Available since v1.1.3.
+* Update test to save Scan ID settings. Refs UITEST-20. 
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/test/ui-testing/error_messages.js
+++ b/test/ui-testing/error_messages.js
@@ -78,6 +78,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait(222)
           .click('#username-checkbox')
           .wait(222)
+          .click('#clickable-savescanid')
           .then(() => { done(); })
           .catch(done);
       });


### PR DESCRIPTION
The Settings pages moved from auto-save-on-change to
you-must-click-submit-to-save. This change clicks the save button to be
sure the required setting is stored.

Fixes [UITEST-20](https://issues.folio.org/browse/UITEST-20).