### PR TITLE
pass keys, not values, to MCL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Extract hardcoded labels so they can be translated. Fixes UICHKOUT-75.
 * Extract proxy modal into `<ProxyManager>`. Fixes STSMACOM-58.
 * Ignore yarn-error.log file. Refs STRIPES-517.
+* Bug fix: translate table-headers fixes patron lookup. Fixes UICHKOUT-411.
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/lib/PatronForm/PatronForm.js
+++ b/lib/PatronForm/PatronForm.js
@@ -11,6 +11,9 @@ import { patronIdentifierMap, patronLabelMap } from '../../constants';
 
 class PatronForm extends React.Component {
   static propTypes = {
+    stripes: PropTypes.shape({
+      intl: PropTypes.object.isRequired,
+    }).isRequired,
     handleSubmit: PropTypes.func.isRequired,
     userIdentifiers: PropTypes.arrayOf(PropTypes.string),
     change: PropTypes.func,
@@ -53,11 +56,19 @@ class PatronForm extends React.Component {
   }
 
   render() {
-    const { userIdentifiers, submitting, handleSubmit } = this.props;
+    const { userIdentifiers, submitting, handleSubmit, stripes: { intl } } = this.props;
     const validationEnabled = false;
     const disableRecordCreation = true;
     const identifier = (userIdentifiers.length > 1) ? 'id' : patronLabelMap[userIdentifiers[0]];
     const { translate } = this.context;
+
+    // map column-IDs to table-header-values
+    const columnMapping = {
+      name: intl.formatMessage({ id: 'ui-checkout.user.name' }),
+      patronGroup: intl.formatMessage({ id: 'ui-checkout.user.patronGroup' }),
+      username: intl.formatMessage({ id: 'ui-checkout.user.username' }),
+      barcode: intl.formatMessage({ id: 'ui-checkout.user.barcode' }),
+    };
 
     return (
       <form id="patron-form" onSubmit={handleSubmit}>
@@ -90,7 +101,8 @@ class PatronForm extends React.Component {
                   sort: 'Name',
                 });
               }}
-              visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
+              visibleColumns={['name', 'patronGroup', 'username', 'barcode']}
+              columnMapping={columnMapping}
               disableRecordCreation={disableRecordCreation}
             />
           </Col>

--- a/translations/en.json
+++ b/translations/en.json
@@ -44,5 +44,10 @@
   "patronIdentifier": "Patron Identifier",
   "scanOrEnterItemBarcode": "Scan or enter item barcode",
   "itemId": "Item ID",
-  "okay": "Okay"
+  "okay": "Okay",
+
+  "user.name": "Name",
+  "user.username": "Username",
+  "user.barcode": "Barcode",
+  "user.patronGroup": "Patron group"
 }


### PR DESCRIPTION
Now that table headers may be i18n'ed, they must be referred to by their
keys, which are constant, rather than their values, which will change
with each translation.

Fixes [UICHKOUT-411](https://issues.folio.org/browse/UICHKOUT-411)