### PR TITLE
Update circulation interface dependency UICHKOUT-420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release 1.2.0 in progress
 
 * Dependency on item-storage: 5.0
+* Dependency on circulation: 3.0
 * Fix spelling of parameter to lookup-users. UIS-71.
 * Remove metadata property from JSON before PUTting settings. UICHKOUT-15.
 * Add Patron info. UICHKOUT-5.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "2.2",
+      "circulation": "3.0",
       "configuration": "2.0",
       "item-storage": "5.0",
       "loan-policy-storage": "1.0",


### PR DESCRIPTION
Following the change in name of the metadata property (from metaData to metadata) the circulation interface version needs updating (from 2.2 to 3.0)