### PR TITLE
UICHKOUT-424: Added link to borrower's open loans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Replace fixedDueDateSchedule with fixedDueDateScheduleId. Fixes UICHKOUT-417.
 * Initialize patron object to empty rather than null. Fixes UICHKOUT-418.
 * Wire up new checkout API. Fixes UICHKOUT-419.
+* Added link to borrower's open loans from the open loans count. Fixes UICHKOUT-424.
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/Scan.js
+++ b/Scan.js
@@ -79,7 +79,6 @@ class Scan extends React.Component {
 
     this.context = context;
     this.store = props.stripes.store;
-    this.connectedViewPatron = props.stripes.connect(ViewPatron);
     this.connectedScanItems = props.stripes.connect(ScanItems);
 
     this.findPatron = this.findPatron.bind(this);
@@ -176,7 +175,7 @@ class Scan extends React.Component {
             />
             {this.state.loading && <Icon icon="spinner-ellipsis" width="10px" />}
             {patrons.length > 0 &&
-              <this.connectedViewPatron
+              <ViewPatron
                 onSelectPatron={this.selectPatron}
                 onClearPatron={this.clearResources}
                 patron={patron}

--- a/lib/UserDetail/UserDetail.js
+++ b/lib/UserDetail/UserDetail.js
@@ -21,7 +21,11 @@ class UserDetail extends React.Component {
       patronGroups: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
+      openLoansCount: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
     }),
+    renderLoans: PropTypes.bool,
   };
 
   static manifest = Object.freeze({
@@ -29,6 +33,10 @@ class UserDetail extends React.Component {
       type: 'okapi',
       path: 'groups?query=(id=!{user.patronGroup})',
       records: 'usergroups',
+    },
+    openLoansCount: {
+      type: 'okapi',
+      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=1',
     },
   });
 
@@ -43,6 +51,24 @@ class UserDetail extends React.Component {
         <strong>Barcode: </strong>
         {user.barcode ? (<Link to={path}>{user.barcode}</Link>) : '-'}
       </span>
+    );
+  }
+
+  renderLoans() {
+    if (!this.props.renderLoans) return null;
+
+    const openLoansCount = _.get(this.props.resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
+    const openLoansPath = `/users/view/${this.props.user.id}?layer=open-loans&query=`;
+    const openLoansLink = <Link to={openLoansPath}>{openLoansCount}</Link>;
+
+    return (
+      <div className={css.section}>
+        <Row>
+          <Col xs={4}>
+            <KeyValue label={this.context.translate('openLoans')} value={openLoansLink} />
+          </Col>
+        </Row>
+      </div>
     );
   }
 
@@ -83,6 +109,8 @@ class UserDetail extends React.Component {
             </Col>
           </Row>
         </div>
+
+        { this.renderLoans() }
       </div>
     );
   }

--- a/lib/ViewPatron/ViewPatron.js
+++ b/lib/ViewPatron/ViewPatron.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
@@ -19,19 +18,7 @@ class ViewPatron extends React.Component {
     proxy: PropTypes.object.isRequired,
     onSelectPatron: PropTypes.func.isRequired,
     onClearPatron: PropTypes.func.isRequired,
-    resources: PropTypes.shape({
-      openLoansCount: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
-    }).isRequired,
   };
-
-  static manifest = Object.freeze({
-    openLoansCount: {
-      type: 'okapi',
-      path: 'circulation/loans?query=(userId=!{patron.id} and status.name<>Closed)&limit=1',
-    },
-  });
 
   constructor(props) {
     super(props);
@@ -43,19 +30,11 @@ class ViewPatron extends React.Component {
 
   render() {
     const { translate } = this.context;
-    const { patron, proxy, resources } = this.props;
-    const openLoansCount = get(resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
+    const { patron, proxy } = this.props;
     const patronDetail = (
       <div>
         <br />
-        <this.connectedPatronDetail id="patron-detail" label={<Headline size="medium">{translate('borrower')}</Headline>} user={patron} {...this.props} />
-        <div className={css.section}>
-          <Row>
-            <Col xs={4}>
-              <KeyValue label={translate('openLoans')} value={openLoansCount} />
-            </Col>
-          </Row>
-        </div>
+        <this.connectedPatronDetail id="patron-detail" label={<Headline size="medium">{translate('borrower')}</Headline>} user={patron} renderLoans {...this.props} />
       </div>
     );
 


### PR DESCRIPTION
* Open Loans count is now a link to the borrower's open loans page.
* Moved the loans count rendering into `<UserDetail>`
* Turned `<ViewPatron>` into a presentation component by removing it's connected-ness in an effort to centralise data-fetching.