### PR TITLE
Add wait time after form load. UITEST-16

### DIFF
--- a/test/ui-testing/error_messages.js
+++ b/test/ui-testing/error_messages.js
@@ -22,7 +22,7 @@ module.exports.test = function uiTest(uiTestCtx) {
       it('should show error when scanning item before patron card', (done) => {
         nightmare
           .wait('#input-item-barcode')
-          .wait(1111)
+          .wait(2222)
           .click('#input-item-barcode')
           .insert('#input-item-barcode', 'item-before-patron')
           .click('#clickable-add-item')


### PR DESCRIPTION
  Have seen the form re-render at times, putting focus back to first
  form field, while the test is attempting to enter value in second field.
  Trying with a little extra time since this step failed in this
  mornings regression test.