### PR TITLE
Add logic to show error message on backend checkout failure, refs UIC…

### DIFF
--- a/ScanItems.js
+++ b/ScanItems.js
@@ -106,7 +106,17 @@ class ScanItems extends React.Component {
         const input = this.itemInput.getRenderedComponent().input;
         setTimeout(() => input.focus());
       })
-      .catch(resp => resp.json().then(error => this.handleErrors(error)))
+      .catch(resp => {
+        if (resp.status >= 500) {
+          return resp.text().then(error => {
+            alert(error); // eslint-disable-line no-alert
+          });
+        } else {
+          return resp.json().then(error => {
+            this.handleErrors(error);
+          });
+        }
+      })
       .finally(() => this.setState({ loading: false }));
   }
 

--- a/lib/PatronForm/PatronForm.js
+++ b/lib/PatronForm/PatronForm.js
@@ -37,7 +37,7 @@ class PatronForm extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     if (!this.barcodeEl) return;
     const input = this.barcodeEl.getRenderedComponent().input;
     // Refocus on the patron barcode input if the submitted value fails


### PR DESCRIPTION
…HKOUT-430

- Added logic to throw an alert message when `responseStatus >= 500`. This is the first of its kind where we are discriminating errors  based on the responses from the new checkout API.
- Currently we have response codes >= 500 sending up responses in plain/text, and hence this needs to be handeled differently than the JSON response sent up for other response codes, like validation
errors on checkout.