### PR TITLE
UIU-497: Added ability to change due date of checked-out items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Adjust columns width on the checkout screen. Fixes UICHKOUT-423.
 * Accomodate ui-users "show inactive users" filter. Refs UIU-400.
 * Remove old code responsible for the checkout processing. Fixes UICHKOUT-431.
+* Added ability to change due date of newly checked-out items. Refs UIU-497.
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/ScanItems.js
+++ b/ScanItems.js
@@ -178,7 +178,7 @@ class ScanItems extends React.Component {
       <div>
         <ItemForm onSubmit={this.checkout} patron={patron} total={scannedTotal} onSessionEnd={onSessionEnd} retrieveRef={this.getChildRef} />
         {this.state.loading && <Icon icon="spinner-ellipsis" width="10px" />}
-        <ViewItem stripes={this.props.stripes} scannedItems={scannedItems} />
+        <ViewItem stripes={this.props.stripes} scannedItems={scannedItems} patron={patron} />
         {settings.audioAlertsEnabled && checkoutStatus &&
         <ReactAudioPlayer
           src={checkoutSound}

--- a/lib/ViewItem/ViewItem.js
+++ b/lib/ViewItem/ViewItem.js
@@ -1,7 +1,9 @@
 import _ from 'lodash';
 import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import ChangeDueDateDialog from '@folio/stripes-smart-components/lib/ChangeDueDateDialog';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 import Button from '@folio/stripes-components/lib/Button';
 import { UncontrolledDropdown } from '@folio/stripes-components/lib/Dropdown';
@@ -23,6 +25,9 @@ class ViewItem extends React.Component {
   static propTypes = {
     scannedItems: PropTypes.arrayOf(PropTypes.object),
     stripes: PropTypes.object,
+    patron: PropTypes.shape({
+      id: PropTypes.string,
+    })
   };
 
   static contextTypes = {
@@ -35,13 +40,19 @@ class ViewItem extends React.Component {
     this.context = context;
     this.formatTime = this.props.stripes.formatTime;
     this.formatDate = this.props.stripes.formatDate;
+
+    this.connectedChangeDueDateDialog = props.stripes.connect(ChangeDueDateDialog);
+
     this.handleOptionsChange = this.handleOptionsChange.bind(this);
     this.onMenuToggle = this.onMenuToggle.bind(this);
     this.onSort = this.onSort.bind(this);
+    this.hideChangeDueDateDialog = this.hideChangeDueDateDialog.bind(this);
 
     this.state = {
       sortOrder: ['no', 'title'],
       sortDirection: ['asc', 'asc'],
+      activeLoan: {},
+      changeDueDateDialogOpen: false,
     };
 
     this.columnMapping = context.translate({
@@ -106,6 +117,19 @@ class ViewItem extends React.Component {
     this.context.history.push(`/settings/circulation/loan-policies/${loan.loanPolicy.id}`);
   }
 
+  changeDueDate(loan) {
+    this.setState({
+      changeDueDateDialogOpen: true,
+      activeLoan: loan.id
+    });
+  }
+
+  hideChangeDueDateDialog() {
+    this.setState({
+      changeDueDateDialogOpen: false,
+    });
+  }
+
   renderActions(loan) {
     return (
       <UncontrolledDropdown
@@ -126,8 +150,26 @@ class ViewItem extends React.Component {
               <Button buttonStyle="dropdownItem" href={`/settings/circulation/loan-policies/${loan.loanPolicy.id}`}>{this.context.translate('loanPolicy')}</Button>
             </MenuItem>
           }
+          <MenuItem itemMeta={{ loan, action: 'changeDueDate' }}>
+            <Button buttonStyle="dropdownItem"><FormattedMessage id="stripes-smart-components.cddd.changeDueDate" /></Button>
+          </MenuItem>
         </DropdownMenu>
       </UncontrolledDropdown>
+    );
+  }
+
+  renderChangeDueDateDialog() {
+    const loan = this.props.scannedItems.find(item => this.state.activeLoan === item.id) || {};
+    const loanIds = [{ id: loan.id }];
+
+    return (
+      <this.connectedChangeDueDateDialog
+        stripes={this.props.stripes}
+        loanIds={loanIds}
+        onClose={this.hideChangeDueDateDialog}
+        open={this.state.changeDueDateDialogOpen}
+        user={this.props.patron}
+      />
     );
   }
 
@@ -140,19 +182,22 @@ class ViewItem extends React.Component {
       [sortMap[sortOrder[0]], sortMap[sortOrder[1]]], sortDirection);
 
     return (
-      <MultiColumnList
-        id="list-items-checked-out"
-        visibleColumns={visibleColumns}
-        columnMapping={this.columnMapping}
-        contentData={contentData}
-        rowMetadata={['id']}
-        formatter={this.getItemFormatter()}
-        columnWidths={{ 'no': 28, 'barcode': 120, 'title': 250, 'loanPolicy': 145, 'dueDate': 75, 'time': 70, ' ': 40 }}
-        isEmptyMessage={this.context.translate('noItemsEntered')}
-        onHeaderClick={this.onSort}
-        sortOrder={sortOrder[0]}
-        sortDirection={`${sortDirection[0]}ending`}
-      />
+      <React.Fragment>
+        <MultiColumnList
+          id="list-items-checked-out"
+          visibleColumns={visibleColumns}
+          columnMapping={this.columnMapping}
+          contentData={contentData}
+          rowMetadata={['id']}
+          formatter={this.getItemFormatter()}
+          columnWidths={{ 'no': 28, 'barcode': 120, 'title': 250, 'loanPolicy': 145, 'dueDate': 75, 'time': 70, ' ': 40 }}
+          isEmptyMessage={this.context.translate('noItemsEntered')}
+          onHeaderClick={this.onSort}
+          sortOrder={sortOrder[0]}
+          sortDirection={`${sortDirection[0]}ending`}
+        />
+        { this.renderChangeDueDateDialog() }
+      </React.Fragment>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@folio/stripes-components": "^2.0.0",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.0",
+    "@folio/stripes-smart-components": "^1.4.15",
     "dateformat": "^2.0.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
This uses the new `ChangeDueDateDialog` functionality introduced in the following PRs:
- https://github.com/folio-org/stripes-smart-components/pull/179
- https://github.com/folio-org/stripes-smart-components/pull/182

Now, upon a checking out an item, the ellipsis menu includes a "Change due date" item which will bring up the Change Due Date dialog for that item.