### PR TITLE
Wait for checkbox settings to load before clicking any UITEST-16

### DIFF
--- a/test/ui-testing/error_messages.js
+++ b/test/ui-testing/error_messages.js
@@ -71,6 +71,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait('a[href="/settings/circulation/checkout"]')
           .click('a[href="/settings/circulation/checkout"]')
           .wait('#username-checkbox')
+          .wait(1111)
           .evaluate(() => {
             const list = document.querySelectorAll('[data-checked="true"]');
             list.forEach(el => (el.click()));


### PR DESCRIPTION
   This is probably what's happening without the wait(1111) before evaluate:

   - test waits for check-boxes to appear (data for populating them may
     still be loading after they appear)
   - test looks for check-boxes that are checked but finds none (if
     data didn't load yet)
   - data finish loading and the username checkbox is typically populated
     with a check-mark
   - assuming that username is NOT checked at this point, the test clicks
     it, thereby un-checking it
   - no checkboxes are thus selected and at least one needs to be,
     so the form cannot be saved
   - test clicks 'Save' to no effect
   - test tries to leave form, and the 'Unsaved changes' modal
     comes up.