### PR TITLE
consistent stripes-components dep with stripes-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * Fix checkout sounds. Fixes UICHKOUT-429.
 * Fix input focus issues. Fixes UICHKOUT-432.
 * Show error messages on error modal. Fixes UICHKOUT-406.
+* stripes-components dep consistent with stripes-core's.
 
 ## [1.1.2](https://github.com/folio-org/ui-checkout/tree/v1.1.2) (2017-09-02)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.1.1...v1.1.2)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@folio/eslint-config-stripes": "^1.1.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.0",
+    "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-smart-components": "^1.4.15",
     "dateformat": "^2.0.0",


### PR DESCRIPTION
The stripes-components dependency was out of sync with stripes-core,
which was causing funky overlaps of the settings pane where the third
column would be superimposed on the second. This probably means we have
our Pane and Paneset components in the wrong repository, or maybe that
we are managing that dependency incorrectly. In any case, the version of
stripes-components we get from stripes-core needs to be the same as the
one we depend on here. And now it is.