### PR TITLE
Add stripes serve to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,18 +59,20 @@
     ]
   },
   "scripts": {
+    "start": "stripes serve",
     "lint": "eslint *.js lib settings test/ui-testing",
     "test": "(cd ../ui-testing; yarn test-module -- -o --run=checkout:error_messages --host=localhost)"
   },
   "devDependencies": {
+    "@folio/eslint-config-stripes": "^1.1.0",
+    "@folio/stripes-cli": "^1.2.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^8.0.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",
-    "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0"
+    "eslint": "^4.8.0"
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",
@@ -80,9 +82,9 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
+    "react-audio-player": "^0.9.0",
     "react-intl": "^2.4.0",
     "react-router-dom": "^4.0.0",
-    "react-audio-player": "^0.9.0",
     "redux-form": "^7.0.3",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
[Stripes CLI](https://github.com/folio-org/stripes-cli) provides a `serve` command that can be used to run a module by itself, without defining an entire platform to run in a `workspace`.

This is handy for:
- working on a single module
- testing a module in isolation
- cutting down the `node` process overhead of running several actively building modules in a local `webpack` server

To use (after a `yarn install`):
```
yarn start
```

By default, `http://localhost:3000` will attempt to connect to a back end at `http://localhost:9130`. To connect to a different Okapi cluster:
```
yarn start --okapi https://my-okapi-cluster.folio.org
```

[Full list of available `stripes serve` options](https://github.com/folio-org/stripes-cli/blob/master/doc/commands.md#serve-command)

Related to https://github.com/folio-org/ui-checkin/pull/51