### PR TITLE
Return undefined from getCheckoutSettings when there are none

### DIFF
--- a/util.js
+++ b/util.js
@@ -23,7 +23,7 @@ export function formatTime(dateStr) {
 }
 
 export function getCheckoutSettings(checkoutSettings) {
-  if (!checkoutSettings.length) return {};
+  if (!checkoutSettings.length) return undefined;
 
   try {
     return JSON.parse(checkoutSettings[0].value);


### PR DESCRIPTION
- Users of that function were expecting a falsey value if unavailable, not an empty Object.