### PR TITLE
Fixed bug where page wouldn't render w/o settings init'd

### DIFF
--- a/Scan.js
+++ b/Scan.js
@@ -149,8 +149,6 @@ class Scan extends React.Component {
 
     const { translate } = this.props;
 
-    if (!checkoutSettings) return <div />;
-
     let patron = patrons[0];
     let proxy = selPatron;
 

--- a/ScanItems.js
+++ b/ScanItems.js
@@ -57,6 +57,10 @@ class ScanItems extends React.Component {
     settings: PropTypes.object,
   };
 
+  static defaultProps = {
+    settings: {},
+  };
+
   constructor(props) {
     super(props);
     this.store = props.stripes.store;


### PR DESCRIPTION
Checkout settings aren't initialised to anything at the start so a brand new build would hit that if-condition and return an empty div after the fix to the checkout test yesterday.

This lets us render, but the user of `checkoutSettings` has a default value to ensure they don't attempt to index into an undefined variable.