### PR TITLE
reset app between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 1.4.0 (IN PROGRESS)
+
+* Reset app between tests. Refs UICHKOUT-448.
+
 ## [1.3.0](https://github.com/folio-org/ui-checkout/tree/v1.3.0) (2018-10-05)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.2.0...v1.3.0)
 


### PR DESCRIPTION
Click out to the settings app bewteen each round of tests to increase
idempotence of the tests. The app needs to be in its virgin state (all
fields empty) at the start of each test in order for those tests to
correctly assess the error messages each test generates. Here, a value
in the item barcode field with an empty patron field causes an error on
the patron-field. But that makes it impossible to test the patron-field
because an error message (albeit, the wrong one) is already present on
the patron field, causing the test to fail. We could add a timer to the
middle of the patron field test to give the (expected-to-fail) patron
lookup function more time to fail, but timers are unreliable.

Arguably, resetting the app between tests is the _right_ approach
anyway. Too bad we don't have a better way to do it.

Refs [UICHKOUT-448](https://issues.folio.org/browse/UICHKOUT-448).