### PR TITLE
UICHKOUT-450: Use documented react-intl patterns instead of stripes.intl

### DIFF
--- a/src/Scan.js
+++ b/src/Scan.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { SubmissionError, reset } from 'redux-form';
 import createInactivityTimer from 'inactivity-timer';
 import { Icon, Pane, Paneset } from '@folio/stripes/components';
+import { intlShape, injectIntl } from 'react-intl';
 
 import PatronForm from './components/PatronForm';
 import ViewPatron from './components/ViewPatron';
@@ -39,7 +40,7 @@ class Scan extends React.Component {
 
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    translate: PropTypes.func,
+    intl: intlShape.isRequired,
     resources: PropTypes.shape({
       scannedItems: PropTypes.arrayOf(
         PropTypes.shape({
@@ -133,12 +134,13 @@ class Scan extends React.Component {
   }
 
   findPatron(data) {
+    const { intl } = this.props;
     const patron = data.patron;
 
     if (!patron) {
       throw new SubmissionError({
         patron: {
-          identifier: this.props.translate('missingDataError'),
+          identifier: intl.formatMessage({ id: 'ui-checkout.missingDataError' }),
         },
       });
     }
@@ -153,7 +155,7 @@ class Scan extends React.Component {
         const identifier = (idents.length > 1) ? 'id' : patronIdentifierMap[idents[0]];
         throw new SubmissionError({
           patron: {
-            identifier: this.props.translate('userNotFoundError', { identifier }),
+            identifier: intl.formatMessage({ id: 'ui-checkout.userNotFoundError' }, { identifier }),
             _error: errorTypes.SCAN_FAILED,
           },
         });
@@ -167,15 +169,13 @@ class Scan extends React.Component {
   }
 
   render() {
-    const resources = this.props.resources;
+    const { resources, intl } = this.props;
     const checkoutSettings = getCheckoutSettings((resources.checkoutSettings || {}).records || []);
     const patrons = (resources.patrons || {}).records || [];
     const settings = (resources.settings || {}).records || [];
     const scannedItems = resources.scannedItems || [];
     const selPatron = resources.selPatron;
     const scannedTotal = scannedItems.length;
-
-    const { translate } = this.props;
 
     let patron = patrons[0];
     let proxy = selPatron;
@@ -188,13 +188,15 @@ class Scan extends React.Component {
     return (
       <div className={css.container}>
         <Paneset static>
-          <Pane defaultWidth="35%" paneTitle={translate('scanPatronCard')}>
+          <Pane
+            defaultWidth="35%"
+            paneTitle={intl.formatMessage({ id: 'ui-checkout.scanPatronCard' })}
+          >
             <PatronForm
               onSubmit={this.findPatron}
               userIdentifiers={this.getPatronIdentifiers()}
               patron={selPatron}
               ref={this.patronFormRef}
-              translate={this.props.translate}
               {...this.props}
             />
             {this.state.loading && <Icon icon="spinner-ellipsis" width="10px" />}
@@ -205,15 +207,16 @@ class Scan extends React.Component {
                 patron={patron}
                 proxy={proxy}
                 settings={settings}
-                translate={this.props.translate}
                 {...this.props}
               />
             }
           </Pane>
-          <Pane defaultWidth="65%" paneTitle={translate('scanItems')}>
+          <Pane
+            defaultWidth="65%"
+            paneTitle={intl.formatMessage({ id: 'ui-checkout.scanItems' })}
+          >
             <this.connectedScanItems
               {...this.props}
-              translate={this.props.translate}
               parentMutator={this.props.mutator}
               parentResources={this.props.resources}
               stripes={this.props.stripes}
@@ -229,11 +232,10 @@ class Scan extends React.Component {
             buttonId="clickable-done-footer"
             total={scannedTotal}
             onSessionEnd={() => this.onSessionEnd()}
-            translate={this.props.translate}
           />}
       </div>
     );
   }
 }
 
-export default Scan;
+export default injectIntl(Scan);

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { SubmissionError, change, stopSubmit, setSubmitFailed } from 'redux-form';
 import { Icon } from '@folio/stripes/components';
 import ReactAudioPlayer from 'react-audio-player';
+import { intlShape, injectIntl } from 'react-intl';
 
 import ItemForm from './components/ItemForm';
 import ViewItem from './components/ViewItem';
@@ -30,7 +31,7 @@ class ScanItems extends React.Component {
 
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    translate: PropTypes.func.isRequired,
+    intl: intlShape.isRequired,
     mutator: PropTypes.shape({
       loanPolicies: PropTypes.shape({
         GET: PropTypes.func,
@@ -71,12 +72,12 @@ class ScanItems extends React.Component {
   }
 
   checkout(data) {
-    const { translate } = this.props;
+    const { intl } = this.props;
 
     if (!data.item) {
       throw new SubmissionError({
         item: {
-          barcode: translate('missingDataError'),
+          barcode: intl.formatMessage({ id: 'ui-checkout.missingDataError' }),
         },
       });
     }
@@ -84,7 +85,7 @@ class ScanItems extends React.Component {
     if (!this.props.patron) {
       return this.dispatchError('patronForm', 'patron.identifier', {
         patron: {
-          identifier: translate('missingDataError'),
+          identifier: intl.formatMessage({ id: 'ui-checkout.missingDataError' }),
         },
       });
     }
@@ -123,8 +124,9 @@ class ScanItems extends React.Component {
 
   handleErrors(error) {
     const { parameters, message } = ((error.errors || [])[0] || {});
+    const { intl } = this.props;
     const itemError = (!parameters || !parameters.length) ?
-      { barcode: this.translate('unknownError'), _error: 'unknownError' } :
+      { barcode: intl.formatMessage({ id: 'ui-checkout.unknownError' }), _error: 'unknownError' } :
       { barcode: message, _error: parameters[0].key };
 
     throw new SubmissionError({ item: itemError });
@@ -163,7 +165,7 @@ class ScanItems extends React.Component {
   }
 
   render() {
-    const { parentResources, onSessionEnd, patron, settings, translate } = this.props;
+    const { parentResources, onSessionEnd, patron, settings } = this.props;
     const { checkoutStatus } = this.state;
     const scannedItems = parentResources.scannedItems || [];
     const scannedTotal = scannedItems.length;
@@ -177,10 +179,9 @@ class ScanItems extends React.Component {
           patron={patron}
           total={scannedTotal}
           onSessionEnd={onSessionEnd}
-          translate={translate}
         />
         {this.state.loading && <Icon icon="spinner-ellipsis" width="10px" />}
-        <ViewItem stripes={this.props.stripes} scannedItems={scannedItems} patron={patron} translate={translate} {...this.props} />
+        <ViewItem stripes={this.props.stripes} scannedItems={scannedItems} patron={patron} {...this.props} />
         {settings.audioAlertsEnabled && checkoutStatus &&
         <ReactAudioPlayer
           src={checkoutSound}
@@ -192,4 +193,4 @@ class ScanItems extends React.Component {
   }
 }
 
-export default ScanItems;
+export default injectIntl(ScanItems);

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -181,7 +181,7 @@ class ScanItems extends React.Component {
           onSessionEnd={onSessionEnd}
         />
         {this.state.loading && <Icon icon="spinner-ellipsis" width="10px" />}
-        <ViewItem stripes={this.props.stripes} scannedItems={scannedItems} patron={patron} {...this.props} />
+        <ViewItem scannedItems={scannedItems} {...this.props} />
         {settings.audioAlertsEnabled && checkoutStatus &&
         <ReactAudioPlayer
           src={checkoutSound}

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -1,24 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
 class ErrorModal extends React.Component {
   static propTypes = {
     open: PropTypes.bool,
     onClose: PropTypes.func,
     message: PropTypes.string,
-    translate: PropTypes.func,
+    intl: intlShape.isRequired,
   };
 
   render() {
-    const { open, message, onClose, translate } = this.props;
+    const { open, message, onClose, intl } = this.props;
 
     return (
-      <Modal onClose={onClose} open={open} size="small" label={translate('itemNotCheckedOut')} dismissible>
+      <Modal
+        onClose={onClose}
+        open={open}
+        size="small"
+        label={intl.formatMessage({ id: 'ui-checkout.itemNotCheckedOut' })}
+        dismissible
+      >
         <p>{message}</p>
         <Col xs={12}>
           <Row end="xs">
-            <Button buttonStyle="primary" onClick={onClose}>{translate('close')}</Button>
+            <Button buttonStyle="primary" onClick={onClose}>
+              <FormattedMessage id="ui-checkout.close" />
+            </Button>
           </Row>
         </Col>
       </Modal>
@@ -26,4 +35,4 @@ class ErrorModal extends React.Component {
   }
 }
 
-export default ErrorModal;
+export default injectIntl(ErrorModal);

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm, reset, getFormSubmitErrors } from 'redux-form';
 import { Col, Button, Row, TextField } from '@folio/stripes/components';
 import { withStripes } from '@folio/stripes/core';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 
 import ScanTotal from '../ScanTotal';
 import ErrorModal from '../ErrorModal';
@@ -14,7 +15,7 @@ class ItemForm extends React.Component {
     submitting: PropTypes.bool,
     patron: PropTypes.object,
     stripes: PropTypes.object,
-    translate: PropTypes.func,
+    intl: intlShape.isRequired,
   };
 
   constructor() {
@@ -56,12 +57,12 @@ class ItemForm extends React.Component {
     const errors = this.getFormErrors();
     const error = errors.item || {};
     return (
-      <ErrorModal open={!isEmpty(error)} onClose={this.clearForm} message={error.barcode} translate={this.props.translate} />
+      <ErrorModal open={!isEmpty(error)} onClose={this.clearForm} message={error.barcode} />
     );
   }
 
   render() {
-    const { submitting, handleSubmit, translate } = this.props;
+    const { submitting, handleSubmit, intl } = this.props;
     const validationEnabled = false;
     return (
       <form id="item-form" onSubmit={handleSubmit}>
@@ -69,8 +70,8 @@ class ItemForm extends React.Component {
           <Col xs={4}>
             <Field
               name="item.barcode"
-              placeholder={translate('scanOrEnterItemBarcode')}
-              aria-label={translate('itemId')}
+              placeholder={intl.formatMessage({ id: 'ui-checkout.scanOrEnterItemBarcode' })}
+              aria-label={intl.formatMessage({ id: 'ui-checkout.itemId' })}
               fullWidth
               id="input-item-barcode"
               component={TextField}
@@ -86,14 +87,14 @@ class ItemForm extends React.Component {
               buttonStyle="primary"
               disabled={submitting}
             >
-              {translate('enter')}
+              <FormattedMessage id="ui-checkout.enter" />
             </Button>
           </Col>
           {
             !isEmpty(this.props.patron) &&
             <Col xs={6}>
               <Row end="xs">
-                <ScanTotal buttonId="clickable-done" {...this.props} translate={this.props.translate} />
+                <ScanTotal buttonId="clickable-done" {...this.props} />
               </Row>
             </Col>
           }
@@ -106,4 +107,4 @@ class ItemForm extends React.Component {
 
 export default reduxForm({
   form: 'itemForm',
-})(withStripes(ItemForm));
+})(withStripes(injectIntl(ItemForm)));

--- a/src/components/PatronForm/PatronForm.js
+++ b/src/components/PatronForm/PatronForm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { Button, Col, Row, TextField } from '@folio/stripes/components';
 import { Pluggable } from '@folio/stripes/core';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 
 import { patronIdentifierMap, patronLabelMap } from '../../constants';
 
@@ -15,21 +16,22 @@ class PatronForm extends React.Component {
     submitting: PropTypes.bool,
     submitFailed: PropTypes.bool,
     patron: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
-    translate: PropTypes.func,
+    intl: intlShape.isRequired
   };
 
   constructor(props) {
     super(props);
+    const { intl } = props;
     this.selectUser = this.selectUser.bind(this);
     this.barcodeEl = React.createRef();
 
     // map column-IDs to table-header-values
-    this.columnMapping = props.translate({
-      name: 'user.name',
-      patronGroup: 'user.patronGroup',
-      username: 'user.username',
-      barcode: 'user.barcode',
-    });
+    this.columnMapping = {
+      name: intl.formatMessage({ id: 'ui-checkout.user.name' }),
+      patronGroup: intl.formatMessage({ id: 'ui-checkout.user.patronGroup' }),
+      username: intl.formatMessage({ id: 'ui-checkout.user.username' }),
+      barcode: intl.formatMessage({ id: 'ui-checkout.user.barcode' })
+    };
   }
 
   componentDidMount() {
@@ -52,7 +54,7 @@ class PatronForm extends React.Component {
   }
 
   selectUser(user) {
-    const { userIdentifiers, handleSubmit } = this.props;
+    const { userIdentifiers, handleSubmit, intl } = this.props;
     const ident = find(userIdentifiers, i => user[patronIdentifierMap[i]]);
 
     if (ident) {
@@ -61,16 +63,15 @@ class PatronForm extends React.Component {
     } else {
       const { username } = user;
       const identifier = patronIdentifierMap[userIdentifiers[0]];
-      Object.assign(user, { error: this.props.translate('missingIdentifierError', { username, identifier }) });
+      Object.assign(user, { error: intl.formatMessage({ id: 'ui-checkout.missingIdentifierError' }, { username, identifier }) });
     }
   }
 
   render() {
-    const { userIdentifiers, submitting, handleSubmit } = this.props;
+    const { userIdentifiers, submitting, handleSubmit, intl } = this.props;
     const validationEnabled = false;
     const disableRecordCreation = true;
     const identifier = (userIdentifiers.length > 1) ? 'id' : patronLabelMap[userIdentifiers[0]];
-    const { translate } = this.props;
 
     return (
       <form id="patron-form" onSubmit={handleSubmit}>
@@ -78,8 +79,8 @@ class PatronForm extends React.Component {
           <Col xs={9}>
             <Field
               name="patron.identifier"
-              placeholder={translate('scanOrEnterPatronId', { identifier })}
-              aria-label={translate('patronIdentifier')}
+              placeholder={intl.formatMessage({ id: 'ui-checkout.scanOrEnterPatronId' }, { identifier })}
+              aria-label={intl.formatMessage({ id: 'ui-checkout.patronIdentifier' })}
               fullWidth
               id="input-patron-identifier"
               component={TextField}
@@ -92,7 +93,7 @@ class PatronForm extends React.Component {
               type="find-user"
               id="clickable-find-user"
               {...this.props}
-              searchLabel={translate('patronLookup')}
+              searchLabel={intl.formatMessage({ id: 'ui-checkout.patronLookup' })}
               marginTop0
               searchButtonStyle="link"
               dataKey="patron"
@@ -116,7 +117,7 @@ class PatronForm extends React.Component {
               buttonStyle="primary"
               disabled={submitting}
             >
-              {translate('enter')}
+              <FormattedMessage id="ui-checkout.enter" />
             </Button>
           </Col>
         </Row>
@@ -127,4 +128,4 @@ class PatronForm extends React.Component {
 
 export default reduxForm({
   form: 'patronForm',
-})(PatronForm);
+})(injectIntl(PatronForm));

--- a/src/components/ScanFooter/ScanFooter.js
+++ b/src/components/ScanFooter/ScanFooter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Row, Col } from '@folio/stripes/components';
 
 import ScanTotal from '../ScanTotal';
@@ -10,14 +9,11 @@ const ScanFooter = props => (
     <Row>
       <Col xsOffset={8} xs={4}>
         <Row end="xs">
-          <ScanTotal buttonId="clickable-done-footer" translate={props.translate} {...props} />
+          <ScanTotal buttonId="clickable-done-footer" {...props} />
         </Row>
       </Col>
     </Row>
   </div>
 );
 
-ScanFooter.propTypes = {
-  translate: PropTypes.func.isRequired,
-};
 export default ScanFooter;

--- a/src/components/ScanTotal/ScanTotal.js
+++ b/src/components/ScanTotal/ScanTotal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@folio/stripes/components';
+import { FormattedMessage } from 'react-intl';
 
 import css from './ScanTotal.css';
 
@@ -9,17 +10,16 @@ class ScanTotal extends React.Component {
     buttonId: PropTypes.string,
     total: PropTypes.number,
     onSessionEnd: PropTypes.func,
-    translate: PropTypes.func,
   };
 
   render() {
-    const { total, buttonId, onSessionEnd, translate } = this.props;
+    const { total, buttonId, onSessionEnd } = this.props;
 
     return (
       <div className={css.root}>
         {total > 0 &&
           <div className={css.label}>
-            {translate('totalItemsScanned', { total })}
+            <FormattedMessage id="ui-checkout.totalItemsScanned" values={{ total }} />
           </div>
         }
         <div>
@@ -28,7 +28,7 @@ class ScanTotal extends React.Component {
             buttonStyle="primary"
             onClick={onSessionEnd}
           >
-            {translate('endSession')}
+            <FormattedMessage id="ui-checkout.endSession" />
           </Button>
         </div>
       </div>

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Col, KeyValue, Row } from '@folio/stripes/components';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { getFullName } from '../../util';
 import css from './UserDetail.css';
 
@@ -20,7 +21,6 @@ class UserDetail extends React.Component {
   });
 
   static propTypes = {
-    stripes: PropTypes.object,
     user: PropTypes.object,
     label: PropTypes.node,
     settings: PropTypes.arrayOf(PropTypes.object),
@@ -32,7 +32,7 @@ class UserDetail extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }),
-    translate: PropTypes.func,
+    intl: intlShape.isRequired,
     renderLoans: PropTypes.bool,
   };
 
@@ -45,7 +45,7 @@ class UserDetail extends React.Component {
           <strong>{getFullName(user)}</strong>
         </Link>
         <strong>
-          {`${this.props.translate('user.barcode')}:`}
+          <FormattedMessage id="ui-checkout.user.detail.barcode" />
         </strong>
         {user.barcode ? (<Link to={path}>{user.barcode}</Link>) : '-'}
       </span>
@@ -54,7 +54,7 @@ class UserDetail extends React.Component {
 
   renderLoans() {
     if (!this.props.renderLoans) return null;
-
+    const { intl } = this.props;
     const openLoansCount = _.get(this.props.resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
     const openLoansPath = `/users/view/${this.props.user.id}?layer=open-loans&query=`;
     const openLoansLink = <Link to={openLoansPath}>{openLoansCount}</Link>;
@@ -63,7 +63,10 @@ class UserDetail extends React.Component {
       <div className={css.section}>
         <Row>
           <Col xs={4}>
-            <KeyValue label={this.props.translate('openLoans')} value={openLoansLink} />
+            <KeyValue
+              label={intl.formatMessage({ id: 'ui-checkout.openLoans' })}
+              value={openLoansLink}
+            />
           </Col>
         </Row>
       </div>
@@ -71,11 +74,11 @@ class UserDetail extends React.Component {
   }
 
   render() {
-    const { user, resources, label, settings, stripes, translate } = this.props;
+    const { user, resources, label, settings, intl } = this.props;
     const patronGroups = (resources.patronGroups || {}).records || [];
     const patronGroup = patronGroups[0] || {};
     const hasProfilePicture = !!(settings.length && settings[0].value === 'true');
-    const statusVal = (_.get(user, ['active'], '') ? 'active' : 'inactive');
+    const statusVal = (_.get(user, ['active'], '') ? 'ui-checkout.active' : 'ui-checkout.inactive');
 
     return (
       <div>
@@ -97,13 +100,22 @@ class UserDetail extends React.Component {
         <div className={css.section}>
           <Row>
             <Col xs={4}>
-              <KeyValue label={translate('patronGroup')} value={patronGroup.group} />
+              <KeyValue
+                label={intl.formatMessage({ id: 'ui-checkout.patronGroup' })}
+                value={patronGroup.group}
+              />
             </Col>
             <Col xs={4}>
-              <KeyValue label={translate('status')} value={translate(statusVal)} />
+              <KeyValue
+                label={intl.formatMessage({ id: 'ui-checkout.status' })}
+                value={intl.formatMessage({ id: statusVal })}
+              />
             </Col>
             <Col xs={4}>
-              <KeyValue label={translate('userExpiration')} value={user.expirationDate ? stripes.formatDate(user.expirationDate) : '-'} />
+              <KeyValue
+                label={intl.formatMessage({ id: 'ui-checkout.userExpiration' })}
+                value={user.expirationDate ? intl.formatDate(user.expirationDate) : '-'}
+              />
             </Col>
           </Row>
         </div>
@@ -114,4 +126,4 @@ class UserDetail extends React.Component {
   }
 }
 
-export default UserDetail;
+export default injectIntl(UserDetail);

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
 import { Button, DropdownMenu, MenuItem, MultiColumnList, UncontrolledDropdown } from '@folio/stripes/components';
@@ -25,13 +25,14 @@ class ViewItem extends React.Component {
       id: PropTypes.string,
     }),
     parentMutator: PropTypes.object.isRequired,
-    translate: PropTypes.func,
+    intl: intlShape.isRequired,
   };
 
   constructor(props) {
     super(props);
-    this.formatTime = this.props.stripes.formatTime;
-    this.formatDate = this.props.stripes.formatDate;
+    const { intl } = props;
+    this.formatTime = intl.formatTime;
+    this.formatDate = intl.formatDate;
     this.handleOptionsChange = this.handleOptionsChange.bind(this);
     this.connectedChangeDueDateDialog = props.stripes.connect(ChangeDueDateDialog);
     this.onMenuToggle = this.onMenuToggle.bind(this);
@@ -45,13 +46,13 @@ class ViewItem extends React.Component {
       changeDueDateDialogOpen: false,
     };
 
-    this.columnMapping = props.translate({
-      no: 'numberAbbreviation',
-      title: 'title',
-      loanPolicy: 'loanPolicy',
-      dueDate: 'dueDate',
-      loanDate: 'time',
-    });
+    this.columnMapping = {
+      no: intl.formatMessage({ id: 'ui-checkout.numberAbbreviation' }),
+      title: intl.formatMessage({ id: 'ui-checkout.title' }),
+      loanPolicy: intl.formatMessage({ id: 'ui-checkout.loanPolicy' }),
+      dueDate: intl.formatMessage({ id: 'ui-checkout.dueDate' }),
+      loanDate: intl.formatMessage({ id: 'ui-checkout.time' }),
+    };
   }
 
   onSort(e, meta) {
@@ -138,19 +139,36 @@ class ViewItem extends React.Component {
         <Button data-role="toggle" buttonStyle="hover dropdownActive"><strong>•••</strong></Button>
         <DropdownMenu data-role="menu" pullRight width="10em">
           <MenuItem itemMeta={{ loan, action: 'showItemDetails' }}>
-            <Button buttonStyle="dropdownItem" href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}?query=`}>{this.props.translate('itemDetails')}</Button>
+            <Button
+              buttonStyle="dropdownItem"
+              href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}?query=`}
+            >
+              <FormattedMessage id="ui-checkout.itemDetails" />
+            </Button>
           </MenuItem>
           <MenuItem itemMeta={{ loan, action: 'showLoanDetails' }}>
-            <Button buttonStyle="dropdownItem" href={`/users/view/${loan.userId}?layer=loan&loan=${loan.id}&query=`}>{this.props.translate('loanDetails')}</Button>
+            <Button
+              buttonStyle="dropdownItem"
+              href={`/users/view/${loan.userId}?layer=loan&loan=${loan.id}&query=`}
+            >
+              <FormattedMessage id="ui-checkout.loanDetails" />
+            </Button>
           </MenuItem>
           {
             this.props.stripes.hasPerm('ui-circulation.settings.loan-policies') &&
             <MenuItem itemMeta={{ loan, action: 'showLoanPolicy' }}>
-              <Button buttonStyle="dropdownItem" href={`/settings/circulation/loan-policies/${loan.loanPolicyId}`}>{this.props.translate('loanPolicy')}</Button>
+              <Button
+                buttonStyle="dropdownItem"
+                href={`/settings/circulation/loan-policies/${loan.loanPolicyId}`}
+              >
+                <FormattedMessage id="ui-checkout.loanPolicy" />
+              </Button>
             </MenuItem>
           }
           <MenuItem itemMeta={{ loan, action: 'changeDueDate' }}>
-            <Button buttonStyle="dropdownItem"><FormattedMessage id="stripes-smart-components.cddd.changeDueDate" /></Button>
+            <Button buttonStyle="dropdownItem">
+              <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
+            </Button>
           </MenuItem>
         </DropdownMenu>
       </UncontrolledDropdown>
@@ -173,6 +191,7 @@ class ViewItem extends React.Component {
   }
 
   render() {
+    const { intl } = this.props;
     const { sortOrder, sortDirection } = this.state;
     const scannedItems = this.props.scannedItems;
     const size = scannedItems.length;
@@ -190,7 +209,7 @@ class ViewItem extends React.Component {
           rowMetadata={['id']}
           formatter={this.getItemFormatter()}
           columnWidths={{ 'no': 28, 'barcode': 120, 'title': 250, 'loanPolicy': 145, 'dueDate': 75, 'time': 70, ' ': 40 }}
-          isEmptyMessage={this.props.translate('noItemsEntered')}
+          isEmptyMessage={intl.formatMessage({ id: 'ui-checkout.noItemsEntered' })}
           onHeaderClick={this.onSort}
           sortOrder={sortOrder[0]}
           sortDirection={`${sortDirection[0]}ending`}
@@ -201,4 +220,4 @@ class ViewItem extends React.Component {
   }
 }
 
-export default ViewItem;
+export default injectIntl(ViewItem);

--- a/src/components/ViewPatron/ViewPatron.js
+++ b/src/components/ViewPatron/ViewPatron.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
 import { Col, Headline, KeyValue, Row } from '@folio/stripes/components';
 import { ProxyManager } from '@folio/stripes/smart-components';
 import UserDetail from '../UserDetail';
@@ -8,7 +9,7 @@ import css from './ViewPatron.css';
 class ViewPatron extends React.Component {
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    translate: PropTypes.func,
+    intl: intlShape.isRequired,
     patron: PropTypes.object.isRequired,
     proxy: PropTypes.object.isRequired,
     onSelectPatron: PropTypes.func.isRequired,
@@ -24,22 +25,36 @@ class ViewPatron extends React.Component {
   }
 
   render() {
-    const { patron, proxy, translate } = this.props;
+    const { patron, proxy, intl } = this.props;
     const patronDetail = (
       <div>
         <br />
-        <this.connectedPatronDetail id="patron-detail" label={<Headline size="medium">{translate('borrower')}</Headline>} user={patron} translate={translate} renderLoans {...this.props} />
+        <this.connectedPatronDetail
+          id="patron-detail"
+          label={<Headline size="medium"><FormattedMessage id="ui-checkout.borrower" /></Headline>}
+          user={patron}
+          renderLoans
+          {...this.props}
+        />
       </div>
     );
 
     const proxyDetail = (
       <div>
         <br />
-        <this.connectedProxyDetail id="proxy-detail" label={translate('borrowerProxy')} user={proxy} translate={translate} {...this.props} />
+        <this.connectedProxyDetail
+          id="proxy-detail"
+          label={intl.formatMessage({ id: 'ui-checkout.borrowerProxy' })}
+          user={proxy}
+          {...this.props}
+        />
         <div className={css.section}>
           <Row>
             <Col xs={4}>
-              <KeyValue label={translate('proxyExpiration')} value="-" />
+              <KeyValue
+                label={intl.formatMessage({ id: 'ui-checkout.proxyExpiration' })}
+                value="-"
+              />
             </Col>
           </Row>
         </div>
@@ -61,4 +76,4 @@ class ViewPatron extends React.Component {
   }
 }
 
-export default ViewPatron;
+export default injectIntl(ViewPatron);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import Switch from 'react-router-dom/Switch';
 import Scan from './Scan';
-import { translate } from './util';
 
 class CheckOutRouting extends React.Component {
   static propTypes = {
@@ -35,13 +34,12 @@ class CheckOutRouting extends React.Component {
 
   render() {
     const { match: { path } } = this.props;
-    const translateMsg = (message, values) => translate(message, values, { namespace: 'ui-checkout' }, this.props.stripes);
     return (
       <Switch>
         <Route
           path={`${path}`}
           render={() => (
-            <this.connectedApp {...this.props} translate={translateMsg} />
+            <this.connectedApp {...this.props} />
           )}
         />
         <Route component={() => { this.NoMatch(); }} />

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,4 @@
-import { get, isString, isArray, isObject, forOwn } from 'lodash';
-import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
-import React from 'react';
-import { FormattedTime } from 'react-intl';
+import { get } from 'lodash';
 
 import { defaultPatronIdentifier, patronIdentifierMap } from './constants';
 
@@ -14,12 +11,6 @@ export function getFullName(user) {
   return `${get(user, ['personal', 'lastName'], '')},
     ${get(user, ['personal', 'firstName'], '')}
     ${get(user, ['personal', 'middleName'], '')}`;
-}
-
-export function formatTime(dateStr) {
-  if (!dateStr) return dateStr;
-  const localDateStr = moment(dateStr).local().format();
-  return (<FormattedTime value={localDateStr} />);
 }
 
 export function getCheckoutSettings(checkoutSettings) {
@@ -46,49 +37,4 @@ export function getPatronIdentifiers(checkoutSettings) {
 export function buildIdentifierQuery(patron, idents) {
   const query = idents.map(ident => `${patronIdentifierMap[ident]}="${patron.identifier}"`);
   return `(${query.join(' OR ')})`;
-}
-
-export function translateMessage(message, values, options = {}, stripes) {
-  const { namespace } = options;
-  const id = namespace ? `${namespace}.${message}` : message;
-  return stripes.intl.formatMessage({ id }, values);
-}
-
-export function translateObject(message, values, options = {}, stripes) {
-  const messageStr = message[options.key];
-  const translated = translateMessage(messageStr, values, options, stripes);
-  return Object.assign(message, { [options.key]: translated });
-}
-
-// Util function to handle some common translation use cases.
-//
-// string: message1 - translate(message1, values)
-// map: { key1: message1, key2: message2 } - translate(map)
-// array of objects: [ { id: 1, value: message1 }, { id: 2, value: message2 } ] - translate(array, {}, { key: 'value' });
-//
-// Available options:
-//
-// namespace - prefix each message
-// key - used with array of objects to indicate which object's property should be translated
-export function translate(message, values, options, stripes) {
-  if (isString(message)) {
-    return translateMessage(message, values, options, stripes);
-  }
-
-  if (isArray(message)) {
-    return message.map(key => (isObject(key) ?
-      translateObject(key, values, options, stripes) :
-      translateMessage(key, values, options, stripes)));
-  }
-
-  if (isObject(message)) {
-    const messages = {};
-    forOwn(message, (value, key) => {
-      messages[key] = translateMessage(value, values, options, stripes);
-    });
-
-    return messages;
-  }
-
-  return message;
 }

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -52,5 +52,6 @@
   "user.name": "Name",
   "user.username": "Username",
   "user.barcode": "Barcode",
+  "user.detail.barcode": "Barcode:",
   "user.patronGroup": "Patron group"
 }


### PR DESCRIPTION
## Purpose
Taking into account that retrieving the intl object from this.context.intl or the stripes god object (stripes.intl) is a deprecated pattern.

The purpose of this PR is to update this repo to only use react-intl constructs outlined at https://github.com/folio-org/stripes-core/blob/master/doc/i18n.md

## Learning
React Intl docs: https://github.com/yahoo/react-intl/wiki


