### PR TITLE
UICHKOUT-450 Replace formatMessage() with <FormattedMessage>

### DIFF
--- a/src/Scan.js
+++ b/src/Scan.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { SubmissionError, reset } from 'redux-form';
 import createInactivityTimer from 'inactivity-timer';
 import { Icon, Pane, Paneset } from '@folio/stripes/components';
-import { intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import PatronForm from './components/PatronForm';
 import ViewPatron from './components/ViewPatron';
@@ -40,7 +40,6 @@ class Scan extends React.Component {
 
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    intl: intlShape.isRequired,
     resources: PropTypes.shape({
       scannedItems: PropTypes.arrayOf(
         PropTypes.shape({
@@ -134,13 +133,12 @@ class Scan extends React.Component {
   }
 
   findPatron(data) {
-    const { intl } = this.props;
     const patron = data.patron;
 
     if (!patron) {
       throw new SubmissionError({
         patron: {
-          identifier: intl.formatMessage({ id: 'ui-checkout.missingDataError' }),
+          identifier: <FormattedMessage id="ui-checkout.missingDataError" />,
         },
       });
     }
@@ -155,7 +153,7 @@ class Scan extends React.Component {
         const identifier = (idents.length > 1) ? 'id' : patronIdentifierMap[idents[0]];
         throw new SubmissionError({
           patron: {
-            identifier: intl.formatMessage({ id: 'ui-checkout.userNotFoundError' }, { identifier }),
+            identifier: <FormattedMessage id="ui-checkout.userNotFoundError" values={{ identifier }} />,
             _error: errorTypes.SCAN_FAILED,
           },
         });
@@ -169,7 +167,7 @@ class Scan extends React.Component {
   }
 
   render() {
-    const { resources, intl } = this.props;
+    const { resources } = this.props;
     const checkoutSettings = getCheckoutSettings((resources.checkoutSettings || {}).records || []);
     const patrons = (resources.patrons || {}).records || [];
     const settings = (resources.settings || {}).records || [];
@@ -190,7 +188,7 @@ class Scan extends React.Component {
         <Paneset static>
           <Pane
             defaultWidth="35%"
-            paneTitle={intl.formatMessage({ id: 'ui-checkout.scanPatronCard' })}
+            paneTitle={<FormattedMessage id="ui-checkout.scanPatronCard" />}
           >
             <PatronForm
               onSubmit={this.findPatron}
@@ -213,7 +211,7 @@ class Scan extends React.Component {
           </Pane>
           <Pane
             defaultWidth="65%"
-            paneTitle={intl.formatMessage({ id: 'ui-checkout.scanItems' })}
+            paneTitle={<FormattedMessage id="ui-checkout.scanItems" />}
           >
             <this.connectedScanItems
               {...this.props}
@@ -238,4 +236,4 @@ class Scan extends React.Component {
   }
 }
 
-export default injectIntl(Scan);
+export default Scan;

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { SubmissionError, change, stopSubmit, setSubmitFailed } from 'redux-form';
 import { Icon } from '@folio/stripes/components';
 import ReactAudioPlayer from 'react-audio-player';
-import { intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import ItemForm from './components/ItemForm';
 import ViewItem from './components/ViewItem';
@@ -31,7 +31,6 @@ class ScanItems extends React.Component {
 
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    intl: intlShape.isRequired,
     mutator: PropTypes.shape({
       loanPolicies: PropTypes.shape({
         GET: PropTypes.func,
@@ -72,12 +71,10 @@ class ScanItems extends React.Component {
   }
 
   checkout(data) {
-    const { intl } = this.props;
-
     if (!data.item) {
       throw new SubmissionError({
         item: {
-          barcode: intl.formatMessage({ id: 'ui-checkout.missingDataError' }),
+          barcode: <FormattedMessage id="ui-checkout.missingDataError" />,
         },
       });
     }
@@ -85,7 +82,7 @@ class ScanItems extends React.Component {
     if (!this.props.patron) {
       return this.dispatchError('patronForm', 'patron.identifier', {
         patron: {
-          identifier: intl.formatMessage({ id: 'ui-checkout.missingDataError' }),
+          identifier: <FormattedMessage id="ui-checkout.missingDataError" />,
         },
       });
     }
@@ -124,9 +121,8 @@ class ScanItems extends React.Component {
 
   handleErrors(error) {
     const { parameters, message } = ((error.errors || [])[0] || {});
-    const { intl } = this.props;
     const itemError = (!parameters || !parameters.length) ?
-      { barcode: intl.formatMessage({ id: 'ui-checkout.unknownError' }), _error: 'unknownError' } :
+      { barcode: <FormattedMessage id="ui-checkout.unknownError" />, _error: 'unknownError' } :
       { barcode: message, _error: parameters[0].key };
 
     throw new SubmissionError({ item: itemError });
@@ -193,4 +189,4 @@ class ScanItems extends React.Component {
   }
 }
 
-export default injectIntl(ScanItems);
+export default ScanItems;

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -1,25 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Col, Modal, Row } from '@folio/stripes/components';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 class ErrorModal extends React.Component {
   static propTypes = {
     open: PropTypes.bool,
     onClose: PropTypes.func,
     message: PropTypes.string,
-    intl: intlShape.isRequired,
   };
 
   render() {
-    const { open, message, onClose, intl } = this.props;
+    const { open, message, onClose } = this.props;
 
     return (
       <Modal
         onClose={onClose}
         open={open}
         size="small"
-        label={intl.formatMessage({ id: 'ui-checkout.itemNotCheckedOut' })}
+        label={<FormattedMessage id="ui-checkout.itemNotCheckedOut" />}
         dismissible
       >
         <p>{message}</p>
@@ -35,4 +34,4 @@ class ErrorModal extends React.Component {
   }
 }
 
-export default injectIntl(ErrorModal);
+export default ErrorModal;

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm, reset, getFormSubmitErrors } from 'redux-form';
 import { Col, Button, Row, TextField } from '@folio/stripes/components';
 import { withStripes } from '@folio/stripes/core';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import ScanTotal from '../ScanTotal';
 import ErrorModal from '../ErrorModal';
@@ -15,7 +15,6 @@ class ItemForm extends React.Component {
     submitting: PropTypes.bool,
     patron: PropTypes.object,
     stripes: PropTypes.object,
-    intl: intlShape.isRequired,
   };
 
   constructor() {
@@ -62,23 +61,31 @@ class ItemForm extends React.Component {
   }
 
   render() {
-    const { submitting, handleSubmit, intl } = this.props;
+    const { submitting, handleSubmit } = this.props;
     const validationEnabled = false;
     return (
       <form id="item-form" onSubmit={handleSubmit}>
         <Row id="section-item">
           <Col xs={4}>
-            <Field
-              name="item.barcode"
-              placeholder={intl.formatMessage({ id: 'ui-checkout.scanOrEnterItemBarcode' })}
-              aria-label={intl.formatMessage({ id: 'ui-checkout.itemId' })}
-              fullWidth
-              id="input-item-barcode"
-              component={TextField}
-              ref={this.barcodeEl}
-              withRef
-              validationEnabled={validationEnabled}
-            />
+            <FormattedMessage id="ui-checkout.scanOrEnterItemBarcode">
+              {placeholder => (
+                <FormattedMessage id="ui-checkout.itemId">
+                  {ariaLabel => (
+                    <Field
+                      name="item.barcode"
+                      placeholder={placeholder}
+                      aria-label={ariaLabel}
+                      fullWidth
+                      id="input-item-barcode"
+                      component={TextField}
+                      ref={this.barcodeEl}
+                      withRef
+                      validationEnabled={validationEnabled}
+                    />
+                  )}
+                </FormattedMessage>
+              )}
+            </FormattedMessage>
           </Col>
           <Col xs={2}>
             <Button
@@ -107,4 +114,4 @@ class ItemForm extends React.Component {
 
 export default reduxForm({
   form: 'itemForm',
-})(withStripes(injectIntl(ItemForm)));
+})(withStripes(ItemForm));

--- a/src/components/PatronForm/PatronForm.js
+++ b/src/components/PatronForm/PatronForm.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { Button, Col, Row, TextField } from '@folio/stripes/components';
 import { Pluggable } from '@folio/stripes/core';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 
 import { patronIdentifierMap, patronLabelMap } from '../../constants';
 
@@ -22,14 +22,13 @@ class PatronForm extends React.Component {
 
   constructor(props) {
     super(props);
-    const { intl } = props;
     this.selectUser = this.selectUser.bind(this);
     // map column-IDs to table-header-values
     this.columnMapping = {
-      name: intl.formatMessage({ id: 'ui-checkout.user.name' }),
-      patronGroup: intl.formatMessage({ id: 'ui-checkout.user.patronGroup' }),
-      username: intl.formatMessage({ id: 'ui-checkout.user.username' }),
-      barcode: intl.formatMessage({ id: 'ui-checkout.user.barcode' })
+      name: <FormattedMessage id="ui-checkout.user.name" />,
+      patronGroup: <FormattedMessage id="ui-checkout.user.patronGroup" />,
+      username: <FormattedMessage id="ui-checkout.user.username" />,
+      barcode: <FormattedMessage id="ui-checkout.user.barcode" />
     };
   }
 
@@ -53,7 +52,7 @@ class PatronForm extends React.Component {
   }
 
   selectUser(user) {
-    const { userIdentifiers, handleSubmit, intl } = this.props;
+    const { userIdentifiers, handleSubmit } = this.props;
     const ident = find(userIdentifiers, i => user[patronIdentifierMap[i]]);
 
     if (ident) {
@@ -62,12 +61,12 @@ class PatronForm extends React.Component {
     } else {
       const { username } = user;
       const identifier = patronIdentifierMap[userIdentifiers[0]];
-      Object.assign(user, { error: intl.formatMessage({ id: 'ui-checkout.missingIdentifierError' }, { username, identifier }) });
+      Object.assign(user, { error: <FormattedMessage id="ui-checkout.missingIdentifierError" values={{ username, identifier }} /> });
     }
   }
 
   render() {
-    const { userIdentifiers, submitting, handleSubmit, intl } = this.props;
+    const { userIdentifiers, submitting, handleSubmit } = this.props;
     const validationEnabled = false;
     const disableRecordCreation = true;
     const identifier = (userIdentifiers.length > 1) ? 'id' : patronLabelMap[userIdentifiers[0]];
@@ -77,23 +76,31 @@ class PatronForm extends React.Component {
       <form id="patron-form" onSubmit={handleSubmit}>
         <Row id="section-patron">
           <Col xs={9}>
-            <Field
-              name="patron.identifier"
-              placeholder={intl.formatMessage({ id: 'ui-checkout.scanOrEnterPatronId' }, { identifier })}
-              aria-label={intl.formatMessage({ id: 'ui-checkout.patronIdentifier' })}
-              fullWidth
-              id="input-patron-identifier"
-              component={TextField}
-              withRef
-              ref={forwardedRef}
-              validationEnabled={validationEnabled}
-            />
+            <FormattedMessage id="ui-checkout.scanOrEnterPatronId" values={{ identifier }}>
+              {placeholder => (
+                <FormattedMessage id="ui-checkout.patronIdentifier">
+                  {ariaLabel => (
+                    <Field
+                      name="patron.identifier"
+                      placeholder={placeholder}
+                      aria-label={ariaLabel}
+                      fullWidth
+                      id="input-patron-identifier"
+                      component={TextField}
+                      withRef
+                      ref={forwardedRef}
+                      validationEnabled={validationEnabled}
+                    />
+                  )}
+                </FormattedMessage>
+              )}
+            </FormattedMessage>
             <Pluggable
               aria-haspopup="true"
               type="find-user"
               id="clickable-find-user"
               {...this.props}
-              searchLabel={intl.formatMessage({ id: 'ui-checkout.patronLookup' })}
+              searchLabel={<FormattedMessage id="ui-checkout.patronLookup" />}
               marginTop0
               searchButtonStyle="link"
               dataKey="patron"
@@ -128,4 +135,4 @@ class PatronForm extends React.Component {
 
 export default reduxForm({
   form: 'patronForm',
-})(injectIntl(PatronForm));
+})(PatronForm);

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Col, KeyValue, Row } from '@folio/stripes/components';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 import { getFullName } from '../../util';
 import css from './UserDetail.css';
 
@@ -32,7 +32,6 @@ class UserDetail extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }),
-    intl: intlShape.isRequired,
     renderLoans: PropTypes.bool,
   };
 
@@ -54,7 +53,6 @@ class UserDetail extends React.Component {
 
   renderLoans() {
     if (!this.props.renderLoans) return null;
-    const { intl } = this.props;
     const openLoansCount = _.get(this.props.resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
     const openLoansPath = `/users/view/${this.props.user.id}?layer=open-loans&query=`;
     const openLoansLink = <Link to={openLoansPath}>{openLoansCount}</Link>;
@@ -64,7 +62,7 @@ class UserDetail extends React.Component {
         <Row>
           <Col xs={4}>
             <KeyValue
-              label={intl.formatMessage({ id: 'ui-checkout.openLoans' })}
+              label={<FormattedMessage id="ui-checkout.openLoans" />}
               value={openLoansLink}
             />
           </Col>
@@ -74,7 +72,7 @@ class UserDetail extends React.Component {
   }
 
   render() {
-    const { user, resources, label, settings, intl } = this.props;
+    const { user, resources, label, settings } = this.props;
     const patronGroups = (resources.patronGroups || {}).records || [];
     const patronGroup = patronGroups[0] || {};
     const hasProfilePicture = !!(settings.length && settings[0].value === 'true');
@@ -101,20 +99,22 @@ class UserDetail extends React.Component {
           <Row>
             <Col xs={4}>
               <KeyValue
-                label={intl.formatMessage({ id: 'ui-checkout.patronGroup' })}
-                value={patronGroup.group}
-              />
+                label={<FormattedMessage id="ui-checkout.patronGroup" />}
+              >
+                {patronGroup.group}
+              </KeyValue>
             </Col>
             <Col xs={4}>
               <KeyValue
-                label={intl.formatMessage({ id: 'ui-checkout.status' })}
-                value={intl.formatMessage({ id: statusVal })}
-              />
+                label={<FormattedMessage id="ui-checkout.status" />}
+              >
+                <FormattedMessage id={statusVal} />
+              </KeyValue>
             </Col>
             <Col xs={4}>
               <KeyValue
-                label={intl.formatMessage({ id: 'ui-checkout.userExpiration' })}
-                value={user.expirationDate ? intl.formatDate(user.expirationDate) : '-'}
+                label={<FormattedMessage id="ui-checkout.userExpiration" />}
+                value={user.expirationDate ? <FormattedDate value={user.expirationDate} /> : '-'}
               />
             </Col>
           </Row>
@@ -126,4 +126,4 @@ class UserDetail extends React.Component {
   }
 }
 
-export default injectIntl(UserDetail);
+export default UserDetail;

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
+import moment from 'moment';
 import React from 'react';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
 import PropTypes from 'prop-types';
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
 import { Button, DropdownMenu, MenuItem, MultiColumnList, UncontrolledDropdown } from '@folio/stripes/components';
@@ -25,14 +25,10 @@ class ViewItem extends React.Component {
       id: PropTypes.string,
     }),
     parentMutator: PropTypes.object.isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
     super(props);
-    const { intl } = props;
-    this.formatTime = intl.formatTime;
-    this.formatDate = intl.formatDate;
     this.handleOptionsChange = this.handleOptionsChange.bind(this);
     this.connectedChangeDueDateDialog = props.stripes.connect(ChangeDueDateDialog);
     this.onMenuToggle = this.onMenuToggle.bind(this);
@@ -47,11 +43,11 @@ class ViewItem extends React.Component {
     };
 
     this.columnMapping = {
-      no: intl.formatMessage({ id: 'ui-checkout.numberAbbreviation' }),
-      title: intl.formatMessage({ id: 'ui-checkout.title' }),
-      loanPolicy: intl.formatMessage({ id: 'ui-checkout.loanPolicy' }),
-      dueDate: intl.formatMessage({ id: 'ui-checkout.dueDate' }),
-      loanDate: intl.formatMessage({ id: 'ui-checkout.time' }),
+      no: <FormattedMessage id="ui-checkout.numberAbbreviation" />,
+      title: <FormattedMessage id="ui-checkout.title" />,
+      loanPolicy: <FormattedMessage id="ui-checkout.loanPolicy" />,
+      dueDate: <FormattedMessage id="ui-checkout.dueDate" />,
+      loanDate: <FormattedMessage id="ui-checkout.time" />,
     };
   }
 
@@ -82,8 +78,8 @@ class ViewItem extends React.Component {
       'title': loan => _.get(loan, ['item', 'title']),
       'loanPolicy': loan => _.get(loan, ['loanPolicy', 'name']),
       'Barcode': loan => _.get(loan, ['item', 'barcode']),
-      'dueDate': loan => (this.formatDate(loan.dueDate)),
-      'Time': loan => (this.formatTime(loan.dueDate)),
+      'dueDate': loan => (<FormattedDate value={loan.dueDate} />),
+      'Time': loan => (<FormattedTime value={loan.dueDate} />),
       ' ': loan => this.renderActions(loan),
     };
   }
@@ -191,7 +187,6 @@ class ViewItem extends React.Component {
   }
 
   render() {
-    const { intl } = this.props;
     const { sortOrder, sortDirection } = this.state;
     const scannedItems = this.props.scannedItems;
     const size = scannedItems.length;
@@ -209,7 +204,7 @@ class ViewItem extends React.Component {
           rowMetadata={['id']}
           formatter={this.getItemFormatter()}
           columnWidths={{ 'barcode': 140, 'title': 180, 'loanPolicy': 150, 'dueDate': 100, 'time': 70, ' ': 40 }}
-          isEmptyMessage={intl.formatMessage({ id: 'ui-checkout.noItemsEntered' })}
+          isEmptyMessage={<FormattedMessage id="ui-checkout.noItemsEntered" />}
           onHeaderClick={this.onSort}
           sortOrder={sortOrder[0]}
           sortDirection={`${sortDirection[0]}ending`}
@@ -220,4 +215,4 @@ class ViewItem extends React.Component {
   }
 }
 
-export default injectIntl(ViewItem);
+export default ViewItem;

--- a/src/components/ViewPatron/ViewPatron.js
+++ b/src/components/ViewPatron/ViewPatron.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, intlShape, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Col, Headline, KeyValue, Row } from '@folio/stripes/components';
 import { ProxyManager } from '@folio/stripes/smart-components';
 import UserDetail from '../UserDetail';
@@ -9,7 +9,6 @@ import css from './ViewPatron.css';
 class ViewPatron extends React.Component {
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    intl: intlShape.isRequired,
     patron: PropTypes.object.isRequired,
     proxy: PropTypes.object.isRequired,
     onSelectPatron: PropTypes.func.isRequired,
@@ -25,7 +24,7 @@ class ViewPatron extends React.Component {
   }
 
   render() {
-    const { patron, proxy, intl } = this.props;
+    const { patron, proxy } = this.props;
     const patronDetail = (
       <div>
         <br />
@@ -44,7 +43,7 @@ class ViewPatron extends React.Component {
         <br />
         <this.connectedProxyDetail
           id="proxy-detail"
-          label={intl.formatMessage({ id: 'ui-checkout.borrowerProxy' })}
+          label={<FormattedMessage id="ui-checkout.borrowerProxy" />}
           user={proxy}
           {...this.props}
         />
@@ -52,7 +51,7 @@ class ViewPatron extends React.Component {
           <Row>
             <Col xs={4}>
               <KeyValue
-                label={intl.formatMessage({ id: 'ui-checkout.proxyExpiration' })}
+                label={<FormattedMessage id="ui-checkout.proxyExpiration" />}
                 value="-"
               />
             </Col>
@@ -76,4 +75,4 @@ class ViewPatron extends React.Component {
   }
 }
 
-export default injectIntl(ViewPatron);
+export default ViewPatron;


### PR DESCRIPTION
Adding `injectIntl()` in a few extra places in https://github.com/folio-org/ui-checkout/pull/196 starting throwing console warnings like:
```
Warning: Failed prop type: Invalid prop `forwardedRef` of type `Object` supplied to `PatronForm`, expected instance of `Element`.
```

By sticking to just `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` components, we can avoid issues around `injectIntl()`.