### PR TITLE
Provide servicePointId during checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "3.0 4.0",
+      "circulation": "3.0 4.0 5.0",
       "configuration": "2.0",
       "item-storage": "5.0 6.0",
       "loan-policy-storage": "1.0",

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -93,12 +93,12 @@ class ScanItems extends React.Component {
     this.setState({ loading: true });
     this.clearError('itemForm');
 
-    const checkoutServicePointId = get(stripes, ['user', 'user', 'curServicePoint', 'id'], '');
+    const servicePointId = get(stripes, ['user', 'user', 'curServicePoint', 'id'], '');
     const loanData = {
       itemBarcode: data.item.barcode,
       userBarcode: patron.barcode,
       loanDate: moment().utc().format(),
-      checkoutServicePointId
+      servicePointId
     };
 
     return mutator.checkout.POST(loanData)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import React from 'react';
 import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
 import PropTypes from 'prop-types';
@@ -71,6 +72,8 @@ class ScanItems extends React.Component {
   }
 
   checkout(data) {
+    const { stripes, mutator, patron } = this.props;
+
     if (!data.item) {
       throw new SubmissionError({
         item: {
@@ -79,7 +82,7 @@ class ScanItems extends React.Component {
       });
     }
 
-    if (!this.props.patron) {
+    if (!patron) {
       return this.dispatchError('patronForm', 'patron.identifier', {
         patron: {
           identifier: <FormattedMessage id="ui-checkout.missingDataError" />,
@@ -90,13 +93,15 @@ class ScanItems extends React.Component {
     this.setState({ loading: true });
     this.clearError('itemForm');
 
+    const checkoutServicePointId = get(stripes, ['user', 'user', 'curServicePoint', 'id'], '');
     const loanData = {
       itemBarcode: data.item.barcode,
-      userBarcode: this.props.patron.barcode,
+      userBarcode: patron.barcode,
       loanDate: moment().utc().format(),
+      checkoutServicePointId
     };
 
-    return this.props.mutator.checkout.POST(loanData)
+    return mutator.checkout.POST(loanData)
       .then(loan => this.fetchLoanPolicy(loan))
       .then(loan => this.addScannedItem(loan))
       .then(() => {


### PR DESCRIPTION
Provide `servicePointId` during checkout. This is required by Okapi interface version circulation v5.0.

Refs [UICHKOUT-460](https://issues.folio.org/browse/UICHKOUT-460)