### PR TITLE
use the "status" formatter for the "active" attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0 (IN PROGRESS)
 * Show `active` column in find-user popup. Refs STCOM-385.
+* Format the `active` attribute as `Status` on the find-user modal. Fixes UICHKOUT-472.
 
 
 ## [1.3.1](https://github.com/folio-org/ui-checkout/tree/v1.3.1) (2018-10-09)

--- a/src/components/PatronForm/PatronForm.js
+++ b/src/components/PatronForm/PatronForm.js
@@ -105,7 +105,7 @@ class PatronForm extends React.Component {
               searchButtonStyle="link"
               dataKey="patrons"
               selectUser={this.selectUser}
-              visibleColumns={['active', 'name', 'patronGroup', 'username', 'barcode']}
+              visibleColumns={['status', 'name', 'patronGroup', 'username', 'barcode']}
               columnMapping={this.columnMapping}
               disableRecordCreation={disableRecordCreation}
             />


### PR DESCRIPTION
`active` is the attribute on the user-object, but the formatter for this
field is named `status` because, um, I don't remember why but that's what
it's called now. So the `<Pluggable>` needs to ask for `status` rather
than `active` for that data to be correctly formatted in the modal.

Fixes [UICHKOUT-472](https://issues.folio.org/browse/UICHKOUT-472)