### PR TITLE
remove extraneous throw clause

### DIFF
--- a/src/Scan.js
+++ b/src/Scan.js
@@ -180,8 +180,6 @@ class Scan extends React.Component {
       }
 
       return patrons;
-    } catch (error) {
-      throw new Error(error.message);
     } finally {
       this.setState({ loading: false });
     }


### PR DESCRIPTION
PR #210 added an extra `catch` block that does not correctly report all
the attributes (specifically, `patron`) that are made available to it
via the `throw` statement above when a patron cannot be found. This
prevents display of the "user not found" error message.