### PR TITLE
use inputRef to access TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Format the `active` attribute as `Status` on the find-user modal. Fixes UICHKOUT-472.
 * Update due date on checkout after changed. Fixes UICHKOUT-470.
 * Fix hardcoded strings. Fixes UICHKOUT-458.
-
+* Simpler input focus due to better ref handling. Refs STCOM-394.
 
 ## [1.3.1](https://github.com/folio-org/ui-checkout/tree/v1.3.1) (2018-10-09)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.3.0...v1.3.1)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -122,8 +122,7 @@ class Scan extends React.Component {
     const current = this.patronFormRef.current;
     // This is not defined when the timeout fires while another app is active: which is fine
     if (current) {
-      const patronFormInst = current.getRenderedComponent();
-      setTimeout(() => patronFormInst.focusInput());
+      setTimeout(() => current.focus());
     }
   }
 

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -68,7 +68,7 @@ class ItemForm extends React.Component {
   }
 
   focusInput() {
-    this.barcodeEl.current.getRenderedComponent().focusInput();
+    this.barcodeEl.current.focus();
   }
 
   renderErrorModal() {
@@ -111,8 +111,7 @@ class ItemForm extends React.Component {
                       fullWidth
                       id="input-item-barcode"
                       component={TextField}
-                      ref={this.barcodeEl}
-                      withRef
+                      inputRef={this.barcodeEl}
                       validationEnabled={validationEnabled}
                     />
                   )}

--- a/src/components/PatronForm/PatronForm.js
+++ b/src/components/PatronForm/PatronForm.js
@@ -23,7 +23,7 @@ class PatronForm extends React.Component {
     submitting: PropTypes.bool,
     submitFailed: PropTypes.bool,
     patron: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
-    forwardedRef: PropTypes.instanceOf(Element)
+    forwardedRef: PropTypes.object,
   };
 
   constructor(props) {
@@ -49,7 +49,7 @@ class PatronForm extends React.Component {
       submitFailed,
     } = this.props;
 
-    const input = forwardedRef.current.getRenderedComponent().getInput();
+    const input = forwardedRef;
 
     // Refocus on the patron barcode input if the submitted value fails
     if (document.activeElement !== input && !patron.id && submitFailed) {
@@ -59,7 +59,9 @@ class PatronForm extends React.Component {
 
   focusInput() {
     const { forwardedRef } = this.props;
-    forwardedRef.current.getRenderedComponent().focusInput();
+    if (forwardedRef.current) {
+      forwardedRef.current.focus();
+    }
   }
 
   selectUser(user) {
@@ -121,8 +123,7 @@ class PatronForm extends React.Component {
                       fullWidth
                       id="input-patron-identifier"
                       component={TextField}
-                      withRef
-                      ref={forwardedRef}
+                      inputRef={forwardedRef}
                       validationEnabled={validationEnabled}
                     />
                   )}


### PR DESCRIPTION
Shamelessly copied from @JohnC-80 in folio-org/ui-checkin#103: 

# Previously....
Checkin had to resort to pushing a ref through the HOC's that
wrap TextField in order to properly obtain a ref so that it
could call instance methods of TextField (`focusInput()`)
This isn't an ideal way for things to be shaped.

# Now....
TextField has a prop: `inputRef` that can be used to obtain a
direct ref to the `<input>` rendered by TextField. This will
punch through any HOC's without needing to rely on
ref-forwarding or `withRef` API. Any usage of `focusInput()`
or `getInput()` can be replaced by the native `focus()`. In
this case, the API to dig up the rendered component
(`getRenderedComponent()`) can be removed as well.

Refs [STCOM-394](https://issues.folio.org/browse/STCOM-394)