### PR TITLE
Adjust item form focus. Fixes UICHKOUT-482.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 1.6.0 IN PROGRESS
+
+* Adjust item form focus. Fixes UICHKOUT-482.
+
 ## [1.5.0](https://github.com/folio-org/ui-checkout/tree/v1.5.0) (2019-01-10)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.4.0...v1.5.0)
 

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -39,7 +39,9 @@ class ItemForm extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.patron) this.focusInput();
+    if (this.props.patron) {
+      this.focusInput();
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -48,17 +50,21 @@ class ItemForm extends React.Component {
       patron,
     } = this.props;
 
-    if (submitSucceeded) this.focusInput();
-    if (!patron || !patron.id) return;
+    if (document.activeElement === this.barcodeEl.current ||
+      !patron || !patron.id) {
+      return;
+    }
+
     // Focus on the item barcode input after the patron is entered
-    if (!prevProps.patron || prevProps.patron.id !== patron.id) {
+    if (submitSucceeded || !prevProps.patron ||
+      prevProps.patron.id !== patron.id) {
+      this.clearForm();
       this.focusInput();
     }
   }
 
   getFormErrors() {
     const { stripes: { store } } = this.props;
-
     return getFormSubmitErrors('itemForm')(store.getState());
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-482

This PR improves the item barcode focus. Previously after checkout has been executed the focusing would end up in an infinite loop causing the checkout module to hang forever. This was happening because `submitSucceeded` from redux-form would stay set to `true`. Reseting the item form after successful checkout resolves the issue. 