### PR TITLE
integration tests must accommodate MCL aria changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 1.7.0 (IN PROGRESS)
+
+* Update integration tests to accommodate MCL aria changes. Fixes UICHKOUT-490.
+
 ## [1.6.0](https://github.com/folio-org/ui-checkout/tree/v1.6.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.5.0...v1.6.0)
 

--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -2,18 +2,21 @@
 module.exports.test = function uiTest(uiTestCtx) {
   const { config, helpers: { login, openApp, logout, circSettingsCheckoutByBarcodeAndUsername }, meta: { testVersion } } = uiTestCtx;
 
-  describe('Module test: checkout:error_messages.', function checkout() {
+  describe('Module test: checkout ("error-messages").', function checkout() {
     const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
     describe('Open app > Trigger error messages > Logout', () => {
-      const uselector = "#list-users div[role='listitem']:nth-of-type(4) > a > div:nth-of-type(3)";
+      const uselector = "#list-users div[role='row'][aria-rowindex='3'] > a > div:nth-of-type(3)";
+
       before((done) => {
         login(nightmare, config, done);
       });
+
       after((done) => {
         logout(nightmare, config, done);
       });
+
       it('should open app and find module version tag', (done) => {
         nightmare
           .use(openApp(nightmare, config, done, 'checkout', testVersion))
@@ -21,9 +24,9 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       /* Why on earth are we clicking into the settings app?!?
-       * Clicking out out to a different app and then back into checkin
+       * Clicking out to a different app and then back into checkin
        * restores checkin to its virgin state with all fields empty.
-       * We need empty fields so we can accurately test the error message
+       * We need empty fields so we can accurately test the error messages
        * that appear when bad data, or out of order data, is added to different
        * fields.
        */

--- a/test/ui-testing/test.js
+++ b/test/ui-testing/test.js
@@ -1,4 +1,4 @@
-const errorMessages = require('./error_messages.js');
+const errorMessages = require('./error-messages.js');
 
 module.exports.test = function uiTest(uiTestCtx) {
   errorMessages.test(uiTestCtx);


### PR DESCRIPTION
Changes to the aria attributes in MCL must be reflected in the
integration tests as well.

Refs [UICHKOUT-490](https://issues.folio.org/browse/UICHKOUT-490), [STCOM-365](https://issues.folio.org/browse/STCOM-365)