### PR TITLE
Update circulation OKAPI interface to v7.0. Part of UICHKOUT-492.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update integration tests to accommodate MCL aria changes. Fixes UICHKOUT-490.
 * Provide unique ID for find-user plugin. Refs UIU-884.
+* Update circulation OKAPI interface to v7.0. Part of UICHKOUT-492.
 
 ## [1.6.0](https://github.com/folio-org/ui-checkout/tree/v1.6.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.5.0...v1.6.0)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "3.0 4.0 5.0 6.0",
+      "circulation": "3.0 4.0 5.0 6.0 7.0",
       "configuration": "2.0",
       "item-storage": "5.0 6.0 7.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-492