### PR TITLE
use correct identifier for plugin's list

### DIFF
--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -7,7 +7,7 @@ module.exports.test = function uiTest(uiTestCtx) {
     this.timeout(Number(config.test_timeout));
 
     describe('Open app > Trigger error messages > Logout', () => {
-      const uselector = "#list-users div[role='row'][aria-rowindex='3'] > a > div:nth-of-type(3)";
+      const uselector = "#list-plugin-find-user div[role='row'][aria-rowindex='3'] > a > div:nth-of-type(3)";
 
       before((done) => {
         login(nightmare, config, done);


### PR DESCRIPTION
folio-org/ui-plugin-find-user/pull/66 changed the way
ui-plugin-find-user provides module information when the plugin is
instantiated. This caused the results-list for a plugin's search to
change from `list-users` to `list-plugin-find-user` because the element
ID is, apparently, constructed from the module ID and we had a bunch of
tests whose selectors needed updating.

Arguably, that PR does The Right Thing by causing the plugin's ID to be
unique instead of matching that of the app it consumes, but it also
highlights the larger issue that plugins really should not be consuming
apps in this manner. It's borderline illegal and just gross.

Aside, this test should be moved to platform-core as, by including a plugin,
it's clearly an integration test rather than a unit test.

Refs [STRIPES-603](https://issues.folio.org/browse/STRIPES-603)