### PR TITLE
sync tests with update plugin markup

### DIFF
--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -7,7 +7,7 @@ module.exports.test = function uiTest(uiTestCtx) {
     this.timeout(Number(config.test_timeout));
 
     describe('Open app > Trigger error messages > Logout', () => {
-      const uselector = "#list-plugin-find-user div[role='row'][aria-rowindex='3'] > a > div:nth-of-type(3)";
+      const uselector = "#list-plugin-find-user div[role='row'][aria-rowindex='3'] > div:nth-of-type(3)";
 
       before((done) => {
         login(nightmare, config, done);


### PR DESCRIPTION
ui-plugin-find-users no longer applies an `<a>` around its rows, so
tests that use the plugin must be updated to reflect this.