### PR TITLE
use exact match for patron IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.8.0 (IN PROGRESS)
 
 * Trim whitespace padding from item barcodes to avoid server errors. Fixes UICHKOUT-506.
+* Use exact matching for user identifiers. Fixes UICHKOUT-510.
 
 ## [1.7.0](https://github.com/folio-org/ui-checkout/tree/v1.7.0) (2019-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.6.0...v1.7.0)

--- a/src/util.js
+++ b/src/util.js
@@ -35,7 +35,7 @@ export function getPatronIdentifiers(checkoutSettings) {
 }
 
 export function buildIdentifierQuery(patron, idents) {
-  const query = idents.map(ident => `${patronIdentifierMap[ident]}="${patron.identifier}"`);
+  const query = idents.map(ident => `${patronIdentifierMap[ident]}=="${patron.identifier}"`);
   return `(${query.join(' OR ')})`;
 }
 


### PR DESCRIPTION
Searches by patron ID must use an exact match, not a wildcard.

Fixes [UICHKOUT-510](https://issues.folio.org/browse/UICHKOUT-510)