### PR TITLE
STSMACOM-152: Removed 'user'-prop from ChangeDueDateDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove spurious, do-nothing settings permission.
 * Add BigTest tests for increased code coverage. Completes UICHKOUT-481.
+* Remove `user`-prop from ChangeDueDateDialog. (STSMACOM-152)
 
 ## [1.8.0](https://github.com/folio-org/ui-checkout/tree/v1.8.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.7.0...v1.8.0)

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -37,9 +37,6 @@ class ViewItem extends React.Component {
   static propTypes = {
     scannedItems: PropTypes.arrayOf(PropTypes.object),
     stripes: PropTypes.object,
-    patron: PropTypes.shape({
-      id: PropTypes.string,
-    }),
     parentMutator: PropTypes.object.isRequired,
     showCheckoutNotes: PropTypes.func,
   };
@@ -258,7 +255,6 @@ class ViewItem extends React.Component {
     const {
       scannedItems,
       stripes,
-      patron,
     } = this.props;
 
     const {

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -275,7 +275,6 @@ class ViewItem extends React.Component {
         loanIds={loanIds}
         onClose={this.hideChangeDueDateDialog}
         open={changeDueDateDialogOpen}
-        user={patron}
       />
     );
   }


### PR DESCRIPTION
The `<ChangeDueDateDialog>`-component from stripes-smart-components no longer requires the presence of a `user`-prop.

**Ticket:** https://issues.folio.org/browse/STSMACOM-152 (no. 4)