### PR TITLE
UICHKOUT-509 - Keyboard navigation ignores Patron look-up link

### DIFF
--- a/src/components/PatronForm/PatronForm.js
+++ b/src/components/PatronForm/PatronForm.js
@@ -127,7 +127,20 @@ class PatronForm extends React.Component {
                 </FormattedMessage>
               )}
             </FormattedMessage>
-
+          </Col>
+          <Col xs={3}>
+            <Button
+              id="clickable-find-patron"
+              type="submit"
+              buttonStyle="primary"
+              disabled={submitting}
+            >
+              <FormattedMessage id="ui-checkout.enter" />
+            </Button>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
             <Pluggable
               aria-haspopup="true"
               type="find-user"
@@ -142,16 +155,6 @@ class PatronForm extends React.Component {
               columnMapping={this.columnMapping}
               disableRecordCreation={disableRecordCreation}
             />
-          </Col>
-          <Col xs={3}>
-            <Button
-              id="clickable-find-patron"
-              type="submit"
-              buttonStyle="primary"
-              disabled={submitting}
-            >
-              <FormattedMessage id="ui-checkout.enter" />
-            </Button>
           </Col>
         </Row>
       </form>


### PR DESCRIPTION
# Purpose
To allow user navigate to patron look-up link by keyboard

# Link
https://issues.folio.org/browse/UICHKOUT-509

#Screenshot
<img width="1440" alt="Screen Shot 2019-06-12 at 13 56 14" src="https://user-images.githubusercontent.com/43472449/59345932-de03ca80-8d19-11e9-9f6b-8f71f8c1e50c.png">
