### PR TITLE
adding missing permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.10.0 (IN PROGRESS)
 
-* Add missing patron-groups permission to "Check out: All permissions" permissions set. Fixes UIU-1078.
+* Add missing permissions to "Check out: All permissions" permissions set. Fixes UIU-1078.
 
 ## [1.9.0](https://github.com/folio-org/ui-checkout/tree/v1.9.0) (2019-06-10)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.8.0...v1.9.0)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
           "configuration.all",
           "users.collection.get",
           "usergroups.collection.get",
+          "proxiesfor.collection.get",
           "module.checkout.enabled",
           "ui-checkout.overrideCheckOutByBarcode"
         ]


### PR DESCRIPTION
Add missing permissions to the "Check out: all" pset that are necessary
for users with proxy relationships.

Refs [UIU-1078](https://issues.folio.org/browse/UIU-1078)