### PR TITLE
UIU-1078 checkout permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
           "users.collection.get",
           "usergroups.collection.get",
           "proxiesfor.collection.get",
+          "accounts.collection.get",
           "module.checkout.enabled",
           "ui-checkout.overrideCheckOutByBarcode"
         ]

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
           "usergroups.collection.get",
           "proxiesfor.collection.get",
           "accounts.collection.get",
+          "manualblocks.collection.get",
           "module.checkout.enabled",
           "ui-checkout.overrideCheckOutByBarcode"
         ]


### PR DESCRIPTION
Add missing permissions to the "Check out: all" pset that are necessary
for users with fees/fines or manual blocks.

Refs [UIU-1078](https://issues.folio.org/browse/UIU-1078)
