### PR TITLE
add missing permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
           "accounts.collection.get",
           "manualblocks.collection.get",
           "module.checkout.enabled",
-          "ui-checkout.overrideCheckOutByBarcode"
+          "ui-checkout.overrideCheckOutByBarcode",
+          "inventory.items.collection.get"
         ]
       }
     ]


### PR DESCRIPTION
Add missing permissions to the "Check out: all" pset that are necessary
to check things out. Any things. Seriously, how did I miss this until
now?

Refs [UIU-1078](https://issues.folio.org/browse/UIU-1078)