### PR TITLE
UICHKOUT-534 - Override non-circulating loan policy does not report name of loan policy

### DIFF
--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -246,6 +246,7 @@ class ScanItems extends React.Component {
       : {
         barcode: message,
         _error: parameters[0].key,
+        loanPolicy: parameters[0].value,
       };
 
     this.reject(new SubmissionError({ item: itemError }));

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -20,6 +20,7 @@ function ErrorModal(props) {
     open,
     onClose,
     message,
+    loanPolicy,
     openOverrideModal,
     stripes,
     item: {
@@ -52,7 +53,7 @@ function ErrorModal(props) {
             ? (
               <SafeHTMLMessage
                 id="ui-checkout.messages.itemIsNotLoanable"
-                values={{ title, barcode, materialType }}
+                values={{ title, barcode, materialType, loanPolicy }}
               />
             )
             : message
@@ -88,6 +89,7 @@ ErrorModal.propTypes = {
   stripes: stripesShape.isRequired,
   onClose: PropTypes.func.isRequired,
   message: PropTypes.string.isRequired,
+  loanPolicy: PropTypes.string.isRequired,
   openOverrideModal: PropTypes.func,
 };
 

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -181,6 +181,7 @@ class ItemForm extends React.Component {
             stripes={stripes}
             item={item || {}}
             message={error.barcode}
+            loanPolicy={error.loanPolicy}
             open={!isEmpty(error)}
             openOverrideModal={this.openOverrideModal}
             onClose={this.clearForm}

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -85,7 +85,7 @@
   "awaitingPickupMessage": "Borrower has <strong>{count}</strong> {count, plural, one {item} other {items}} awaiting pickup at this service point.",
   "awaitingPickupLabel": "Items awaiting pickup",
 
-  "messages.itemIsNotLoanable": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) is not <strong>loanable</strong> according to the <strong>Non-circulating</strong> loan policy.",
+  "messages.itemIsNotLoanable": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) is not <strong>loanable</strong> according to the <strong>{loanPolicy}</strong> loan policy.",
   "messages.itemWillBeCheckedOut": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) will be <strong>checked out</strong>.",
   "cddd.date": "Date",
   "cddd.time": "Time",


### PR DESCRIPTION
# Purpose
Add loan policy name to error modal on override.

# Link
https://issues.folio.org/browse/UICHKOUT-534

# Screenshot
![Screenshot_12](https://user-images.githubusercontent.com/43472449/64694261-f6fb5380-d4a1-11e9-9892-f8c5e2b61bd4.png)
