### PR TITLE
Handle tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-checkout
 
 ## [1.12.0] (IN PROGRESS)
+* Handle tests in accordance with the fact that now MCL rows are not always a `div`
 
 ## [1.11.0](https://github.com/folio-org/ui-checkout/tree/v1.11.0) (2019-09-10)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.10.0...v1.11.0)

--- a/test/bigtest/interactors/check-out.js
+++ b/test/bigtest/interactors/check-out.js
@@ -103,7 +103,7 @@ export default interactor(class CheckOutInteractor {
   errorModal = new ErrorModal();
   overrideModal = new OverrideModal();
   checkoutNoteModal = new CheckoutNoteModalInteractor();
-  items = collection('#list-items-checked-out [class*=mclRowContainer---] div[class^="mclRow--"]', Item);
+  items = collection('#list-items-checked-out [class*=mclRowContainer---] [class^="mclRow---"]', Item);
 
   patronErrorPresent = isPresent('#section-patron [class*=feedbackError---]');
   itemErrorPresent = isPresent('#section-item [class*=feedbackError---]');


### PR DESCRIPTION
## Purpose

In accordance with the fact that now MCL rows are not always a `div`.