### PR TITLE
UITEST-70 be less markupy, more semantic

### DIFF
--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -7,7 +7,7 @@ module.exports.test = function uiTest(uiTestCtx) {
     this.timeout(Number(config.test_timeout));
 
     describe('Open app > Trigger error messages > Logout', () => {
-      const uselector = "#list-plugin-find-user div[role='row'][aria-rowindex='3'] > div:nth-of-type(3)";
+      const uselector = "#list-plugin-find-user [role='row'][aria-rowindex='3'] > div:nth-of-type(3)";
 
       before((done) => {
         login(nightmare, config, done);


### PR DESCRIPTION
Nightmare appears to be getting hung up in some MCL selections. I'm not
sure how this is coming up now given that this passed for several days,
but here we are. Removing some of the markup and leaving the selector to
stand on semantic markup alone seems to do the trick.

Refs [UITEST-70](https://issues.folio.org/browse/UITEST-70)