### PR TITLE
Revert "UICHKOUT-543: Update the circulation API to support changes in the rule editor"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "3.0 4.0 5.0 6.0 7.0 8.0",
+      "circulation": "3.0 4.0 5.0 6.0 7.0",
       "configuration": "2.0",
       "item-storage": "5.0 6.0 7.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
Reverts folio-org/ui-checkout#380

Reverting only so we can tag a patch release at tip-of-master; this is the only feature-commit since v1.11.0 was released and reverting (and then reapplying) a single PR will be easier than cherry-picking everything since this PR onto a release branch. Yes, yes, we may want to investigate a different branching strategy like GitFlow in the long term to mitigate this process. Today, I just need to publish a release.