### PR TITLE
UIU-1177: Make change the due date button available on checked out loans when a user has loan edit permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for ui-checkout
 
 ## 1.12.0 (IN PROGRESS)
-
+* Make change due date button available on checked out loans when user has loan edit permission. Part of UIU-1177.
 
 ## [1.11.1](https://github.com/folio-org/ui-checkout/tree/v1.11.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.0...v1.11.1)

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -3,8 +3,9 @@ import moment from 'moment';
 import React from 'react';
 import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
 import PropTypes from 'prop-types';
-import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
 
+import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
+import { IfPermission } from '@folio/stripes/core';
 import {
   Button,
   DropdownMenu,
@@ -234,11 +235,17 @@ class ViewItem extends React.Component {
                 </Button>
               </MenuItem>
             }
-            <MenuItem itemMeta={{ loan, action: 'changeDueDate' }}>
-              <Button data-test-date-picker buttonStyle="dropdownItem">
-                <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
-              </Button>
-            </MenuItem>
+            {
+              stripes.hasPerm('ui-users.loans.edit') &&
+              <MenuItem
+                itemMeta={{ loan, action: 'changeDueDate' }}
+                onSelectItem={this.handleOptionsChange}
+              >
+                <Button data-test-date-picker buttonStyle="dropdownItem">
+                  <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
+                </Button>
+              </MenuItem>
+            }
             { checkoutNotePresent &&
               <MenuItem itemMeta={{ loan, action: 'showCheckoutNotes' }}>
                 <div data-test-checkout-notes>


### PR DESCRIPTION
## Purpose 

Make change the due date button available on checked out loans when a user has loan edit permission as part of [UIU-1177](https://issues.folio.org/browse/UIU-1177). This permission works in conjunction with permissions for the loans check out.