### PR TITLE
UICHKOUT-553 better handling for expired requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.12.0 (IN PROGRESS)
 * Make change due date button available on checked out loans when user has loan edit permission. Part of UIU-1177.
+* Ignore 'Closed - pickup expired' items in request queries. Refs UICHKOUT-553. 
 
 ## [1.11.1](https://github.com/folio-org/ui-checkout/tree/v1.11.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.0...v1.11.1)

--- a/src/util.js
+++ b/src/util.js
@@ -42,7 +42,7 @@ export function buildIdentifierQuery(patron, idents) {
 export function buildRequestQuery(requesterId, servicePointId) {
   return `(requesterId==${requesterId} and
     pickupServicePointId=${servicePointId} and
-    (status=="Closed - Pickup expired" or status=="Open - Awaiting pickup"))`;
+    status=="Open - Awaiting pickup")`;
 }
 
 export function to(promise) {


### PR DESCRIPTION
Do not include items with the request-status `Closed - pickup expired`
when searching for a user's requests during checkout.

Refs [UICHKOUT-553](https://issues.folio.org/browse/UICHKOUT-553)