### PR TITLE
avoid diku_admin in tests

### DIFF
--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -98,6 +98,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait('#clickable-filter-active-active')
           .click('#clickable-filter-active-active')
           .wait(uselector)
+          .wait(15000)
           .click(uselector)
           .wait('#patron-form ~ div a > strong')
           .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging


### PR DESCRIPTION
The code for plucking a user from the patron-look-up pop-up could allow
for `diku_admin`, a user without a barcode, to be selected. This caused
issues with downstream tests that expect the user to have a barcode.