### PR TITLE
avoid admin users in tests

### DIFF
--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -72,10 +72,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait('#section-patron div[class*="Error"]')
           .evaluate(() => {
             const errorText = document.querySelector('#section-patron div[class*="Error"]').innerText;
-            if (!errorText.startsWith('User with this')) {
-              throw new Error(`Error message not found for invalid user input: ${errorText}`);
-            }
-            if (!errorText.endsWith('does not exist')) {
+            if (!(errorText.startsWith('User with this') && errorText.endsWith('does not exist'))) {
               throw new Error(`Error message not found for invalid user input: ${errorText}`);
             }
           })

--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -72,8 +72,11 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait('#section-patron div[class*="Error"]')
           .evaluate(() => {
             const errorText = document.querySelector('#section-patron div[class*="Error"]').innerText;
-            if (!errorText.startsWith('User')) {
-              throw new Error('Error message not found for invalid user input');
+            if (!errorText.startsWith('User with this')) {
+              throw new Error(`Error message not found for invalid user input: ${errorText}`);
+            }
+            if (!errorText.endsWith('does not exist')) {
+              throw new Error(`Error message not found for invalid user input: ${errorText}`);
             }
           })
           .then(done)
@@ -95,10 +98,13 @@ module.exports.test = function uiTest(uiTestCtx) {
           .insert('#input-patron-identifier', null)
           .wait('#clickable-find-user')
           .click('#clickable-find-user')
+          .wait('#clickable-filter-pg-faculty')
+          .click('#clickable-filter-pg-faculty')
           .wait('#clickable-filter-active-active')
           .click('#clickable-filter-active-active')
+          .wait(() => !document.querySelectorAll('#OverlayContainer [class^="noResultsMessage"]').length)
+          .wait('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
           .wait(uselector)
-          .wait(15000)
           .click(uselector)
           .wait('#patron-form ~ div a > strong')
           .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging
@@ -114,7 +120,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .evaluate(() => {
             const errorText = document.querySelector('#section-item div[class*="Error"]').innerText;
             if (!errorText.startsWith('No item with barcode')) {
-              throw new Error('Error message not found for wrong item barcode');
+              throw new Error(`Error message not found for wrong item barcode: ${errorText}`);
             }
           })
           .then(done)


### PR DESCRIPTION
The code for plucking a user from the patron-look-up pop-up could allow
for `diku`, a user without a barcode, to be selected. This caused
issues with downstream tests that expect the user to have a barcode.

Somebody utterly botched an earlier attempt to do this exact thing in
PR #404 but must have pushed up the wrong branch because that only
contained an extra timer, useful for inspecting what happened in the
test, but useless in terms of actually fixing it. What a moron. Another
nail in the coffin for having the privilege of merging your own PRs.
Sure, it can be expedient, but it can also be stupid. I am living
proof.