### PR TITLE
UICHKOUT-535: Implement check out circulating items permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.12.0 (IN PROGRESS)
 * Make change due date button available on checked out loans when user has loan edit permission. Part of UIU-1177.
-* Ignore 'Closed - pickup expired' items in request queries. Refs UICHKOUT-553. 
+* Ignore 'Closed - pickup expired' items in request queries. Refs UICHKOUT-553.
+* Implement check out circulating items permission. Refs UICHKOUT-535. 
 
 ## [1.11.1](https://github.com/folio-org/ui-checkout/tree/v1.11.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.0...v1.11.1)

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
         ]
       },
       {
-        "permissionName": "ui-checkout.all",
-        "displayName": "Check out: All permissions",
-        "description": "Entire set of permissions needed to use Check out",
+        "permissionName": "ui-checkout.circulation",
+        "displayName": "Check out: Check out circulating items",
+        "description": "Set of permissions needed to check out circulation items",
         "visible": true,
         "subPermissions": [
           "circulation.all",
@@ -57,8 +57,17 @@
           "accounts.collection.get",
           "manualblocks.collection.get",
           "module.checkout.enabled",
-          "ui-checkout.overrideCheckOutByBarcode",
           "inventory.items.collection.get"
+        ]
+      },
+      {
+        "permissionName": "ui-checkout.all",
+        "displayName": "Check out: All permissions",
+        "description": "Entire set of permissions needed to use Check out",
+        "visible": true,
+        "subPermissions": [
+          "ui-checkout.circulation",
+          "ui-checkout.overrideCheckOutByBarcode"
         ]
       }
     ]


### PR DESCRIPTION
## Purpose

Implement **Check out: Check out circulating items** permission as part of [UICHKOUT-535](https://issues.folio.org/browse/UICHKOUT-535). The only difference at the moment with existing **Check out: All permissions** permission is that the later also allows overriding of non-circulating loan policies.