### PR TITLE
UICHKOUT-562: Extend "okapiInterfaces" with "inventory" in order to handle permissions error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Make change due date button available on checked out loans when user has loan edit permission. Part of UIU-1177.
 * Ignore 'Closed - pickup expired' items in request queries. Refs UICHKOUT-553.
 * Implement check out circulating items permission. Refs UICHKOUT-535. 
+* Extend "okapiInterfaces" with "inventory" in order to handle permissions error. Refs UICHKOUT-562.
 
 ## [1.11.1](https://github.com/folio-org/ui-checkout/tree/v1.11.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.0...v1.11.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkout",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "description": "Item Check-out",
   "repository": "folio-org/ui-checkout",
   "publishConfig": {
@@ -28,7 +28,8 @@
       "configuration": "2.0",
       "item-storage": "5.0 6.0 7.0",
       "loan-policy-storage": "1.0 2.0",
-      "users": "15.0"
+      "users": "15.0",
+      "inventory": "9.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose

Extend _okapiInterfaces_ with _inventory_ interface in order to handle permissions error on _folio-snapshot_ environment.