### PR TITLE
UICHKOUT-557: Hide the empty checkout items list message during the checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Ignore 'Closed - pickup expired' items in request queries. Refs UICHKOUT-553.
 * Implement check out circulating items permission. Refs UICHKOUT-535. 
 * Extend "okapiInterfaces" with "inventory" in order to handle permissions error. Refs UICHKOUT-562.
+* Hide the empty checkout items list message during the checkout of the new item. Refs UICHKOUT-557.
 
 ## [1.11.1](https://github.com/folio-org/ui-checkout/tree/v1.11.1) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.0...v1.11.1)

--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^1.1.0"
+  },
+  "resolutions": {
+    "fake-xml-http-request": "2.0.0"
   }
 }

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -1,11 +1,12 @@
 import { get } from 'lodash';
 import React from 'react';
-import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import { SubmissionError, change, stopSubmit, setSubmitFailed } from 'redux-form';
-import { Icon } from '@folio/stripes/components';
 import ReactAudioPlayer from 'react-audio-player';
 import { FormattedMessage } from 'react-intl';
+
+import { Icon } from '@folio/stripes/components';
 
 import ItemForm from './components/ItemForm';
 import ViewItem from './components/ViewItem';
@@ -367,6 +368,7 @@ class ScanItems extends React.Component {
         }
         <ViewItem
           scannedItems={scannedItems}
+          loading={loading}
           showCheckoutNotes={this.showCheckoutNotes}
           {...this.props}
         />

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -5,7 +5,6 @@ import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
-import { IfPermission } from '@folio/stripes/core';
 import {
   Button,
   DropdownMenu,
@@ -42,6 +41,7 @@ class ViewItem extends React.Component {
       id: PropTypes.string,
     }),
     parentMutator: PropTypes.object.isRequired,
+    loading: PropTypes.bool.isRequired,
     showCheckoutNotes: PropTypes.func,
   };
 
@@ -296,6 +296,7 @@ class ViewItem extends React.Component {
   render() {
     const {
       scannedItems,
+      loading,
     } = this.props;
 
     const {
@@ -307,6 +308,7 @@ class ViewItem extends React.Component {
     const items = scannedItems.map((it, index) => ({ ...it, no: size - index }));
     const contentData = _.orderBy(items,
       [sortMap[sortOrder[0]], sortMap[sortOrder[1]]], sortDirection);
+    const emptyMessage = !loading ? <FormattedMessage id="ui-checkout.noItemsEntered" /> : null;
 
     return (
       <React.Fragment>
@@ -318,11 +320,11 @@ class ViewItem extends React.Component {
           rowMetadata={['id']}
           formatter={this.getItemFormatter()}
           columnWidths={columnWidths}
-          isEmptyMessage={<FormattedMessage id="ui-checkout.noItemsEntered" />}
-          onHeaderClick={this.onSort}
+          isEmptyMessage={emptyMessage}
           sortOrder={sortOrder[0]}
           sortDirection={`${sortDirection[0]}ending`}
           interactive={false}
+          onHeaderClick={this.onSort}
         />
         {this.renderChangeDueDateDialog()}
       </React.Fragment>

--- a/test/bigtest/interactors/check-out.js
+++ b/test/bigtest/interactors/check-out.js
@@ -116,6 +116,7 @@ export default interactor(class CheckOutInteractor {
 
   multipieceModal = new MultipieceModalInteractor('#multipiece-modal');
   itemList = new MultiColumnListInteractor('#list-items-checked-out');
+  itemListEmptyMessage = text('[data-test-scan-items] [class*=mclEmptyMessage---]');
 
   whenUserIsLoaded() {
     return this.when(() => this.patronFullName.isPresent);

--- a/test/bigtest/tests/check-out-test.js
+++ b/test/bigtest/tests/check-out-test.js
@@ -99,7 +99,7 @@ describe('CheckOut', () => {
         .clickPatronBtn();
     });
 
-    describe('checking out a single item', () => {
+    describe('checking out a single item successfully', () => {
       beforeEach(async function () {
         this.server.create('item', {
           barcode: '123',
@@ -112,6 +112,21 @@ describe('CheckOut', () => {
       it('shows a list of checked out items', () => {
         expect(checkOut.scanItems.itemListPresent).to.be.true;
         expect(checkOut.items().length).to.equal(1);
+      });
+
+      it('should hide item list empty message during checkout', () => {
+        expect(checkOut.itemListEmptyMessage).to.equal('');
+      });
+    });
+
+    describe('checking out a single item unsuccessfully', () => {
+      beforeEach(async function () {
+        this.server.post('/circulation/check-out-by-barcode', {}, 500);
+        await checkOut.checkoutItem('123');
+      });
+
+      it('should hide item list empty message during checkout', () => {
+        expect(checkOut.itemListEmptyMessage).to.equal('');
       });
     });
 


### PR DESCRIPTION
## Purpose
Hide the empty checkout items list message during the checkout of the new item in the scope of [UICHKOUT-557](https://issues.folio.org/browse/UICHKOUT-557).

## Screenshot
![chrome-capture](https://user-images.githubusercontent.com/40821852/69623397-7f25d980-104b-11ea-9c14-3d188aab8a28.gif)
