### PR TITLE
Add "circulation.end-patron-action-session.post" sub-permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.12.0 (IN PROGRESS)
 * Make change due date button available on checked out loans when user has loan edit permission. Part of UIU-1177.
 * Ignore 'Closed - pickup expired' items in request queries. Refs UICHKOUT-553.
-* Implement check out circulating items permission. Refs UICHKOUT-535. 
+* Implement check out circulating items permission. Refs UICHKOUT-535.
 * Extend "okapiInterfaces" with "inventory" in order to handle permissions error. Refs UICHKOUT-562.
 * Hide the empty checkout items list message during the checkout of the new item. Refs UICHKOUT-557.
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
           "accounts.collection.get",
           "manualblocks.collection.get",
           "module.checkout.enabled",
-          "inventory.items.collection.get"
+          "inventory.items.collection.get",
+          "circulation.end-patron-action-session.post"
         ]
       },
       {

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -48,16 +48,10 @@ function ErrorModal(props) {
       dismissible
     >
       <p>
-        {
-          canBeOverridden
-            ? (
-              <SafeHTMLMessage
-                id="ui-checkout.messages.itemIsNotLoanable"
-                values={{ title, barcode, materialType, loanPolicy }}
-              />
-            )
-            : message
-        }
+        <SafeHTMLMessage
+          id="ui-checkout.messages.itemIsNotLoanable"
+          values={{ title, barcode, materialType, loanPolicy }}
+        />
       </p>
       <Col xs={12}>
         <Row end="xs">


### PR DESCRIPTION
## Purpose

1) Add "circulation.end-patron-action-session.post" sub-permission in order to prevent error when a user has either "Check out: All permissions" or "Check out: Check out circulations items" permissions.
2) Show the proper message when user is not able to override the loan policy

## Screenshot

<img width="1414" alt="Screen Shot 2019-12-02 at 17 58 32" src="https://user-images.githubusercontent.com/40821852/69974185-6591ff80-152d-11ea-8e34-c6a657f81bc0.png">
