### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,5 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^1.1.0"
-  },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
   }
 }


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.