### PR TITLE
UICHKOUT-554: Fix link to loans list in user details information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.1.0 (IN PROGRESS)
 
+* Fix link path to loans list in user details information. Fixes UICHKOUT-554.
+
 ## [2.0.0](https://github.com/folio-org/ui-checkout/tree/v2.0.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.2...v2.0.0)
 

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -97,7 +97,7 @@ class UserDetail extends React.Component {
     if (!renderLoans) return null;
 
     const openLoansCount = get(resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
-    const openLoansPath = `/users/view/${user.id}?layer=open-loans&query=`;
+    const openLoansPath = `/users/${user.id}/loans/open`;
     const openLoansLink = <Link to={openLoansPath}>{openLoansCount}</Link>;
     const patronGroups = get(resources, ['patronGroups', 'records', 0, 'group'], '');
     const openAccounts = get(resources, ['openAccounts', 'records'], []);


### PR DESCRIPTION
## Purposes

Fix link to loans list in user details information in the scope of the ticket [UICHKOUT-554](https://issues.folio.org/browse/UICHKOUT-554).

