### PR TITLE
UICHKOUT-580: Handle the wrong error message when checking out requested items to non-requester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 
 * Fix link path to loans list in user details information. Fixes UICHKOUT-554.
+* Handle the wrong error message when checking out requested items to non-requester. Fixes UICHKOUT-580.
 
 ## [2.0.0](https://github.com/folio-org/ui-checkout/tree/v2.0.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.2...v2.0.0)

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -12,7 +12,10 @@ import {
   Row,
 } from '@folio/stripes/components';
 
-import { OVERRIDABLE_ERROR_MESSAGES } from '../../constants';
+import {
+  ITEM_NOT_LOANABLE,
+  OVERRIDABLE_ERROR_MESSAGES,
+} from '../../constants';
 
 
 function ErrorModal(props) {
@@ -37,6 +40,7 @@ function ErrorModal(props) {
 
   const canBeOverridden = stripes.hasPerm('ui-checkout.overrideCheckOutByBarcode')
     && OVERRIDABLE_ERROR_MESSAGES.includes(message);
+  const isItemNotLoanable = message === ITEM_NOT_LOANABLE;
 
   return (
     <Modal
@@ -48,10 +52,16 @@ function ErrorModal(props) {
       dismissible
     >
       <p>
-        <SafeHTMLMessage
-          id="ui-checkout.messages.itemIsNotLoanable"
-          values={{ title, barcode, materialType, loanPolicy }}
-        />
+        {
+          isItemNotLoanable
+            ? (
+              <SafeHTMLMessage
+                id="ui-checkout.messages.itemIsNotLoanable"
+                values={{ title, barcode, materialType, loanPolicy }}
+              />
+            )
+            : message
+        }
       </p>
       <Col xs={12}>
         <Row end="xs">

--- a/src/components/OverrideModal/OverrideModal.js
+++ b/src/components/OverrideModal/OverrideModal.js
@@ -21,7 +21,7 @@ import { DueDatePicker } from '@folio/stripes/smart-components';
 
 import {
   DATE_PICKER_DEFAULTS,
-  INVALIDE_DATE_MESSAGE,
+  INVALID_DATE_MESSAGE,
 } from '../../constants';
 
 function OverrideModal(props) {
@@ -44,7 +44,7 @@ function OverrideModal(props) {
     setDatetime(newDateTime);
   };
 
-  const canBeSubmitted = comment && dueDate !== INVALIDE_DATE_MESSAGE;
+  const canBeSubmitted = comment && dueDate !== INVALID_DATE_MESSAGE;
 
   const onSubmit = async (event) => {
     event.preventDefault();

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,7 +28,8 @@ export const INVALIDE_DATE_MESSAGE = 'Invalid date';
 
 export const defaultPatronIdentifier = 'BARCODE';
 
-export const OVERRIDABLE_ERROR_MESSAGES = ['Item is not loanable'];
+export const ITEM_NOT_LOANABLE = 'Item is not loanable';
+export const OVERRIDABLE_ERROR_MESSAGES = [ITEM_NOT_LOANABLE];
 
 export const statuses = {
   CHECK_OUT: 'Check out',

--- a/src/constants.js
+++ b/src/constants.js
@@ -24,7 +24,7 @@ export const DATE_PICKER_DEFAULTS = {
   time: '23:59:00.000Z',
 };
 
-export const INVALIDE_DATE_MESSAGE = 'Invalid date';
+export const INVALID_DATE_MESSAGE = 'Invalid date';
 
 export const defaultPatronIdentifier = 'BARCODE';
 

--- a/test/ui-testing/error-messages.js
+++ b/test/ui-testing/error-messages.js
@@ -113,9 +113,9 @@ module.exports.test = function uiTest(uiTestCtx) {
         nightmare
           .insert('#input-item-barcode', 'wrong-item-barcode')
           .click('#clickable-add-item')
-          .wait('#section-item div[class*="Error"]')
+          .wait('#OverlayContainer [class^="modalContent--"]')
           .evaluate(() => {
-            const errorText = document.querySelector('#section-item div[class*="Error"]').innerText;
+            const errorText = document.querySelector('#OverlayContainer [class^="modalContent--"]').innerText;
             if (!errorText.startsWith('No item with barcode')) {
               throw new Error(`Error message not found for wrong item barcode: ${errorText}`);
             }


### PR DESCRIPTION
## Purpose

Handle the wrong error message when checking out the requested items to non-requester which was introduced as a part of #422. The current issue is affecting other types of errors as well.