### PR TITLE
bump to version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for ui-checkout
 
-## 2.1.0 (IN PROGRESS)
+## 3.0.0 (IN PROGRESS)
 
 * Fix link path to loans list in user details information. Fixes UICHKOUT-554.
 * Handle the wrong error message when checking out requested items to non-requester. Fixes UICHKOUT-580.
 * Make the Check out ellipsis accessible. Refs UICHKOUT-558.
 * Update okapiInterfaces: `item-storage:8.0`, `inventory:10.0`, `circulation:9.0`. Part of UICHKOUT-585.
 * Security update eslint to v6.2.1. Refs UICHKOUT-586.
+* Migrate to `stripes` `v3.0.0` and move `react-intl` and `react-router` to peerDependencies.
 
 ## [2.0.0](https://github.com/folio-org/ui-checkout/tree/v2.0.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v1.11.2...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkout",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Item Check-out",
   "repository": "folio-org/ui-checkout",
   "publishConfig": {
@@ -88,10 +88,10 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",
-    "@folio/stripes-components": "~5.10.0",
-    "@folio/stripes": "^2.13.0",
+    "@folio/stripes-components": "~6.0.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.11.0",
-    "@folio/stripes-core": "^3.12.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^10.0.3",
     "regenerator-runtime": "^0.13.3",
     "core-js": "^3.6.4",
@@ -112,13 +112,13 @@
     "prop-types": "^15.5.10",
     "react-audio-player": "^0.9.0",
     "react-hot-loader": "^4.3.12",
-    "react-intl": "^2.4.0",
-    "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.13.0",
-    "react": "*"
+    "@folio/stripes": "^3.0.0",
+    "react": "*",
+    "react-intl": "^2.4.0",
+    "react-router-dom": "^4.0.0"
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^1.1.0"


### PR DESCRIPTION
Why a new major version?

* bump the `@folio/stripes` peer to `v3.0.0`
* move `react-router` related things to peerDependencies
* move `react-intl` to peerDependencies