### PR TITLE
UICHKOUT-607 - Three identical e-mail notices for one checkout

### DIFF
--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -280,7 +280,10 @@ class CheckOut extends React.Component {
   async onSessionEnd() {
     const {
       resources: { activeRecord: { patronId } },
-      mutator: { endSession: { POST: endSession } },
+      mutator: {
+        endSession: { POST: endSession },
+        activeRecord: { update: updateParonId }
+      },
     } = this.props;
 
     this.clearResources();
@@ -297,14 +300,8 @@ class CheckOut extends React.Component {
     }
 
     if (patronId) {
-      await endSession({
-        endSessions : [
-          {
-            actionType: 'Check-out',
-            patronId
-          }
-        ]
-      });
+      await endSession({ endSessions : [{ actionType: 'Check-out', patronId }] });
+      updateParonId({});
     }
   }
 

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -282,7 +282,7 @@ class CheckOut extends React.Component {
       resources: { activeRecord: { patronId } },
       mutator: {
         endSession: { POST: endSession },
-        activeRecord: { update: updateParonId }
+        activeRecord: { update }
       },
     } = this.props;
 
@@ -301,7 +301,7 @@ class CheckOut extends React.Component {
 
     if (patronId) {
       await endSession({ endSessions : [{ actionType: 'Check-out', patronId }] });
-      updateParonId({});
+      update({});
     }
   }
 


### PR DESCRIPTION
# Purpose
Clean up patronId from activeRecord in case when session was closed.

# Link
https://issues.folio.org/browse/UICHKOUT-607