### PR TITLE
UICHKOUT-610/611: Fix bug preventing continuation after cancelling checkout notes or multipiece modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.1.0] (IN PROGRESS)
 
 * Change selected parton background color to increase color contrast. Refs UICHKOUT-603. 
+* Fix bug preventing continuation after cancelling checkout notes or multipiece modal. Fixes UICHKOUT-610, UICHKOUT-611.
 
 ## [3.0.0](https://github.com/folio-org/ui-checkout/tree/v3.0.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v2.0.0...v3.0.0)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -320,7 +320,7 @@ class ScanItems extends React.Component {
     // to clear the form or deal with errors in this case -- only
     // when the mode is false, meaning that notes were shown as
     // part of the item checkout workflow.
-    if (this.state.checkoutNotesMode) {
+    if (!this.state.checkoutNotesMode) {
       this.clearField('itemForm', 'item.barcode');
       this.reject(new SubmissionError({}));
     }

--- a/src/components/MultipieceModal/MultipieceModal.js
+++ b/src/components/MultipieceModal/MultipieceModal.js
@@ -21,7 +21,7 @@ const MultipieceModal = (props) => {
       <Button data-test-multipiece-modal-confirm-btn buttonStyle="primary" onClick={() => onConfirm(item)}>
         <FormattedMessage id="ui-checkout.multipieceModal.confirm" />
       </Button>
-      <Button onClick={onClose}>
+      <Button data-test-multipiece-modal-cancel-btn onClick={onClose}>
         <FormattedMessage id="ui-checkout.multipieceModal.cancel" />
       </Button>
     </ModalFooter>

--- a/test/bigtest/interactors/check-out.js
+++ b/test/bigtest/interactors/check-out.js
@@ -7,6 +7,7 @@ import {
   Interactor,
   collection,
   count,
+  value,
 } from '@bigtest/interactor';
 
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
@@ -41,6 +42,7 @@ export default interactor(class CheckOutInteractor {
   endSessionBtnPresent = isPresent('#clickable-done');
 
   patronFullName = text('[data-test-check-out-patron-full-name]');
+  itemBarcode = value('#input-item-barcode');
 
   errorModal = new ErrorModal();
   overrideModal = new OverrideModal();

--- a/test/bigtest/interactors/checkout-note-modal.js
+++ b/test/bigtest/interactors/checkout-note-modal.js
@@ -7,6 +7,7 @@ import {
 @interactor class CheckoutNoteModalInteractor {
   present = isPresent('[data-test-checkoutnotemodal-confirm-button]');
   clickConfirm = clickable('[data-test-checkoutnotemodal-confirm-button]');
+  clickCancel = clickable('[data-test-checkoutnotemodal-cancel-button]');
 }
 
 export default CheckoutNoteModalInteractor;

--- a/test/bigtest/interactors/multipiece-modal.js
+++ b/test/bigtest/interactors/multipiece-modal.js
@@ -7,6 +7,7 @@ import {
 @interactor class MultipieceModalInteractor {
   present = isPresent('[data-test-multipiece-modal-confirm-btn]');
   clickConfirm = clickable('[data-test-multipiece-modal-confirm-btn]');
+  clickCancel = clickable('[data-test-multipiece-modal-cancel-btn]');
 }
 
 export default MultipieceModalInteractor;

--- a/test/bigtest/tests/check-out-test.js
+++ b/test/bigtest/tests/check-out-test.js
@@ -215,6 +215,16 @@ describe('CheckOut', () => {
       it('shows multipiece modal', () => {
         expect(checkOut.multipieceModal.present).to.be.true;
       });
+
+      describe('cancelling the multipiece modal', () => {
+        beforeEach(async function () {
+          await checkOut.multipieceModal.clickCancel();
+        });
+
+        it('clears the barcode field', () => {
+          expect(checkOut.itemBarcode).to.equal('');
+        });
+      });
     });
 
     describe('checking out item with Checkout Notes', () => {
@@ -242,6 +252,16 @@ describe('CheckOut', () => {
 
       it('shows checkoutNote modal', () => {
         expect(checkOut.checkoutNoteModal.present).to.be.true;
+      });
+
+      describe('cancelling the checkout note modal', () => {
+        beforeEach(async function () {
+          await checkOut.checkoutNoteModal.clickCancel();
+        });
+
+        it('clears the barcode field', () => {
+          expect(checkOut.itemBarcode).to.equal('');
+        });
       });
     });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-610
https://issues.folio.org/browse/UICHKOUT-611

This fixes a bug that would cause the UI to get stuck if one of the two modals (multipiece or checkout notes) were cancelled during the checkout process. The Enter button would be disabled, making it impossible to check out other items without ending the session. 

The new behavior clears the barcode input field and re-enables the Enter button so scanning can continue blissfully.

<img width="965" alt="Screen Shot 2020-04-02 at 4 05 37 PM" src="https://user-images.githubusercontent.com/1322242/78296750-49fb2d80-74fc-11ea-9d7a-8b8da7d92a9d.png">
<img width="871" alt="Screen Shot 2020-04-02 at 4 05 43 PM" src="https://user-images.githubusercontent.com/1322242/78296753-4b2c5a80-74fc-11ea-8610-1404fdadb89b.png">
