### PR TITLE
UICHKOUT-610, -611 do not halt after closing modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## [3.1.0] (IN PROGRESS)
+
+* Fix bug preventing continuation after cancelling checkout notes or multipiece modal. Fixes UICHKOUT-610, UICHKOUT-611.
+
 ## [3.0.0](https://github.com/folio-org/ui-checkout/tree/v3.0.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v2.0.0...v3.0.0)
 

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -320,7 +320,7 @@ class ScanItems extends React.Component {
     // to clear the form or deal with errors in this case -- only
     // when the mode is false, meaning that notes were shown as
     // part of the item checkout workflow.
-    if (this.state.checkoutNotesMode) {
+    if (!this.state.checkoutNotesMode) {
       this.clearField('itemForm', 'item.barcode');
       this.reject(new SubmissionError({}));
     }


### PR DESCRIPTION
Fix bug preventing continuation after cancelling checkout notes or multipiece modal 

Refs [UICHKOUT-610](https://issues.folio.org/browse/UICHKOUT-610), [UICHKOUT-611](https://issues.folio.org/browse/UICHKOUT-611)