### PR TITLE
@folio devdeps MUST use caret deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@folio/eslint-config-stripes": "^5.1.0",
     "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.11.0",
-    "@folio/stripes-components": "~6.0.0",
+    "@folio/stripes-components": "^6.0.0",
     "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",


### PR DESCRIPTION
The dev-dep on `@folio/stripes-components` MUST be a caret dep
compatible with the selected version of stripes, otherwise it risks
pulling multiple copies into the build because of a newer version
present in `@folio/stripes`.

This bug was introduced in #441 and inadvertently carried through other
updates but we didn't realize it until now, when `v6.1.0` was published,
putting it out of sync with the `~6.0` version here.