### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change selected parton background color to increase color contrast. Refs UICHKOUT-603.
 * Fix bug preventing continuation after cancelling checkout notes or multipiece modal. Fixes UICHKOUT-610, UICHKOUT-611.
 * Show confirmation modal when item with withdrawn status is scanned. Refs UICHKOUT-605.
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 
 ## [3.0.0](https://github.com/folio-org/ui-checkout/tree/v3.0.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v2.0.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -123,5 +123,8 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^2.0.0"
+  },
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@folio/react-intl-safe-html": "^1.0.0",
     "inactivity-timer": "^1.0.0",
     "lodash": "^4.17.4",
-    "moment": "^2.0.0",
+    "moment": "~2.24.0",
     "prop-types": "^15.5.10",
     "react-audio-player": "^0.9.0",
     "react-hot-loader": "^4.3.12",


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)