### PR TITLE
STRIPES-672 update react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.0.0] (IN PROGRESS)
 
 * Upgrade to `stripes` `4.0`, `react-intl` `4.5`. Refs STRIPES-672.
+* Upgrade to `react-intl-safe-html` `2.0`. Refs STRIPES-672.
 
 ## [3.1.0] (IN PROGRESS)
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.0",
+    "@folio/react-intl-safe-html": "^2.0.0",
     "inactivity-timer": "^1.0.0",
     "lodash": "^4.17.4",
     "moment": "~2.24.0",


### PR DESCRIPTION
Update `react-intl-safe-html` to `2.0` to maintain compatibility with
`react-intl` `4.5`.

Refs [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)