### PR TITLE
UICHKOUT-614 restore checkout-as-proxy

### DIFF
--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -8,6 +8,11 @@ import {
 } from 'react-intl';
 
 import {
+  withStripes,
+  stripesShape,
+} from '@folio/stripes/core';
+
+import {
   Col,
   KeyValue,
   Row,
@@ -42,8 +47,9 @@ class UserDetail extends React.Component {
 
   static propTypes = {
     user: PropTypes.object,
+    id: PropTypes.string.isRequired,
     label: PropTypes.node,
-    settings: PropTypes.arrayOf(PropTypes.object),
+    settings: PropTypes.arrayOf(PropTypes.object).isRequired,
     resources: PropTypes.shape({
       patronGroups: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -59,9 +65,7 @@ class UserDetail extends React.Component {
       }),
     }),
     renderLoans: PropTypes.bool,
-    stripes: PropTypes.shape({
-      hasPerm: PropTypes.func.isRequired,
-    }).isRequired,
+    stripes: stripesShape.isRequired,
   };
 
   getUserValue = (user) => {
@@ -170,6 +174,7 @@ class UserDetail extends React.Component {
 
   render() {
     const {
+      id,
       user,
       resources,
       label,
@@ -182,7 +187,7 @@ class UserDetail extends React.Component {
     const statusVal = (get(user, ['active'], '') ? 'ui-checkout.active' : 'ui-checkout.inactive');
 
     return (
-      <div>
+      <div id={id}>
         <div>
           <Row>
             <Col xs={hasProfilePicture ? 10 : 12}>
@@ -234,4 +239,4 @@ class UserDetail extends React.Component {
   }
 }
 
-export default UserDetail;
+export default withStripes(UserDetail);

--- a/src/components/ViewPatron/ViewPatron.js
+++ b/src/components/ViewPatron/ViewPatron.js
@@ -23,6 +23,7 @@ class ViewPatron extends React.Component {
     onClearPatron: PropTypes.func.isRequired,
     openBlockedModal: PropTypes.func,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
+    settings: PropTypes.arrayOf(PropTypes.object),
   };
 
   constructor(props) {
@@ -41,6 +42,7 @@ class ViewPatron extends React.Component {
       onClearPatron,
       patronBlocks,
       openBlockedModal,
+      settings
     } = this.props;
 
     const patronDetail = (
@@ -55,6 +57,7 @@ class ViewPatron extends React.Component {
           }
           user={patron}
           renderLoans
+          settings={settings}
           {...this.props}
         />
       </div>
@@ -67,6 +70,7 @@ class ViewPatron extends React.Component {
           id="proxy-detail"
           label={<FormattedMessage id="ui-checkout.borrowerProxy" />}
           user={proxy}
+          settings={settings}
         />
         <div className={css.section}>
           <Row>

--- a/test/bigtest/interactors/check-out.js
+++ b/test/bigtest/interactors/check-out.js
@@ -22,6 +22,7 @@ import CheckoutNoteModalInteractor from './checkout-note-modal';
 import ErrorModal from './error-modal';
 import OverrideModal from './override-modal';
 import Item from './item';
+import ProxyModalInteractor from './proxy-modal';
 
 export default interactor(class CheckOutInteractor {
   static defaultScope = '[data-test-check-out-scan]';
@@ -29,6 +30,7 @@ export default interactor(class CheckOutInteractor {
   scanItems = new ScanItemsInteractor('[data-test-scan-items]');
   itemMenu = new ItemMenuInteractor();
   blockModal = new BlockModalInteractor();
+  proxyModal = new ProxyModalInteractor();
 
   openRequestsCount = new Interactor('[data-test-open-requests-count]');
   patronIdentifierPresent = isPresent('#input-patron-identifier');
@@ -43,7 +45,8 @@ export default interactor(class CheckOutInteractor {
   clickEndSessionBtn = clickable('#clickable-done');
   endSessionBtnPresent = isPresent('#clickable-done');
 
-  patronFullName = text('[data-test-check-out-patron-full-name]');
+  patronFullName = text('#patron-detail [data-test-check-out-patron-full-name]');
+  proxyFullName = text('#proxy-detail [data-test-check-out-patron-full-name]');
   itemBarcode = value('#input-item-barcode');
 
   errorModal = new ErrorModal();
@@ -55,6 +58,8 @@ export default interactor(class CheckOutInteractor {
 
   patronErrorPresent = isPresent('#section-patron [class*=feedbackError---]');
   confirmWithdrawnModalPresent = isPresent('#test-confirm-withdrawn-modal');
+  patronDetailIsPresent = isPresent('#patron-detail');
+  proxyDetailIsPresent = isPresent('#proxy-detail');
 
   checkoutItem(barcode) {
     return this
@@ -72,5 +77,9 @@ export default interactor(class CheckOutInteractor {
 
   whenItemListIsPresent() {
     return this.when(() => this.itemList.rowCount > 0);
+  }
+
+  whenProxyModalIsPresent() {
+    return this.when(() => this.proxyModal.isPresent);
   }
 });

--- a/test/bigtest/interactors/proxy-modal.js
+++ b/test/bigtest/interactors/proxy-modal.js
@@ -1,0 +1,16 @@
+import {
+  clickable,
+  interactor,
+  isPresent,
+} from '@bigtest/interactor';
+
+@interactor class ProxyModalInteractor {
+  modalPresent = isPresent('#proxy-form');
+  clickAsSelf = clickable('[data-test-acting-as-self]');
+  clickAsProxy = clickable('[data-test-acting-as-proxy]');
+
+  clickContinue = clickable('#OverlayContainer [data-test-continue-button]');
+  clickCancel = clickable('#OverlayContainer [data-test-cancel-button]');
+}
+
+export default ProxyModalInteractor;

--- a/test/bigtest/network/models/proxiesfor.js
+++ b/test/bigtest/network/models/proxiesfor.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/test/bigtest/network/scenarios/proxies.js
+++ b/test/bigtest/network/scenarios/proxies.js
@@ -1,0 +1,60 @@
+import CQLParser from '../cql';
+
+export default function proxies(server) {
+  server.post('/circulation/check-out-by-barcode', ({ loans, items }, request) => {
+    const params = JSON.parse(request.requestBody);
+    const item = items.findBy({ barcode: params.itemBarcode });
+
+    return loans.findBy({ itemId: item.id });
+  });
+
+  server.create('user', {
+    barcode: 'deadbeef',
+    personal: {
+      firstName: 'The',
+      lastName: 'Patron'
+    }
+  });
+  server.create('user', {
+    barcode: 'c0ffee',
+    personal: {
+      firstName: 'The',
+      lastName: 'Sponsor'
+    }
+  });
+
+  server.get('users', ({ users }, request) => {
+    let user = {};
+    const url = new URL(request.url);
+    const cqlQuery = url.searchParams.get('query');
+
+    if (cqlQuery != null) {
+      const cqlParser = new CQLParser();
+      cqlParser.parse(cqlQuery);
+      if (cqlParser.tree.term) {
+        user = users.where({ barcode: cqlParser.tree.term });
+      }
+    }
+
+    return user;
+  });
+
+  server.get('/proxiesfor', {
+    'proxiesFor' : [{
+      'userId' : 'c0ffee',
+      'proxyUserId' : 'deadbeef',
+      'id' : '0ccf4867-a5bd-4ffd-89eb-f080a82ff864',
+      'requestForSponsor' : 'Yes',
+      'notificationsTo' : 'Sponsor',
+      'accrueTo' : 'Sponsor',
+      'status' : 'Active',
+      'metadata' : {
+        'createdDate' : '2020-05-17T11:13:05.788+0000',
+        'createdByUserId' : '1477c52a-fa25-56b4-92bd-b6dfde924695',
+        'updatedDate' : '2020-05-17T11:13:05.788+0000',
+        'updatedByUserId' : '1477c52a-fa25-56b4-92bd-b6dfde924695'
+      }
+    }],
+    'totalRecords' : 1
+  });
+}

--- a/test/bigtest/tests/proxy-test.js
+++ b/test/bigtest/tests/proxy-test.js
@@ -1,0 +1,107 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import CheckOutInteractor from '../interactors/check-out';
+
+const checkOut = new CheckOutInteractor();
+const proxy = {
+  barcode: 'deadbeef',
+  personal: {
+    firstName: 'The',
+    lastName: 'Patron',
+  },
+};
+const sponsor = {
+  barcode: 'c0ffee',
+  personal: {
+    firstName: 'The',
+    lastName: 'Sponsor',
+  },
+};
+
+describe('checkout with proxy', function () {
+  setupApplication({
+    scenarios: ['proxies'],
+  });
+
+
+  beforeEach(function () {
+    return this.visit('/checkout', () => {
+      expect(checkOut.$root).to.exist;
+    });
+  });
+
+  describe('checkout', () => {
+    beforeEach(async function () {
+      await checkOut
+        .fillPatronBarcode(proxy.barcode)
+        .clickPatronBtn()
+        .whenUserIsLoaded();
+    });
+
+    it('proxy modal is displayed', () => {
+      expect(checkOut.proxyModal.modalPresent).to.be.true;
+    });
+
+    describe('click cancel', () => {
+      beforeEach(async function () {
+        await checkOut.proxyModal.clickCancel();
+      });
+
+      it('closes proxy modal', () => {
+        expect(checkOut.proxyModal.modalPresent).to.be.false;
+      });
+
+      it('patron information is empty', () => {
+        expect(checkOut.patronDetailIsPresent).to.be.false;
+      });
+    });
+
+    describe('continue as self', () => {
+      beforeEach(async function () {
+        await checkOut.proxyModal.clickAsSelf();
+        await checkOut.proxyModal.clickContinue();
+      });
+
+      it('closes proxy modal', () => {
+        expect(checkOut.proxyModal.modalPresent).to.be.false;
+      });
+
+      it('displays patron information', () => {
+        expect(checkOut.patronDetailIsPresent).to.be.true;
+      });
+
+      it('displays patron information', () => {
+        expect(checkOut.patronFullName).to.equal(`${proxy.personal.lastName}, ${proxy.personal.firstName}`);
+      });
+    });
+
+    describe('continue as sponsor', () => {
+      beforeEach(async function () {
+        await checkOut.proxyModal.clickAsProxy();
+        await checkOut.proxyModal.clickContinue();
+      });
+
+      it('closes proxy modal', () => {
+        expect(checkOut.proxyModal.modalPresent).to.be.false;
+      });
+
+      it('displays patron information', () => {
+        expect(checkOut.patronDetailIsPresent).to.be.true;
+      });
+
+      it('borrower information contains sponsor details', () => {
+        expect(checkOut.patronFullName).to.equal(`${sponsor.personal.lastName}, ${sponsor.personal.firstName}`);
+      });
+
+      it('displays proxy information', () => {
+        expect(checkOut.patronDetailIsPresent).to.be.true;
+      });
+
+      it('proxy information information contains patron details', () => {
+        expect(checkOut.proxyFullName).to.equal(`${proxy.personal.lastName}, ${proxy.personal.firstName}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
`props.settings`, which is used to determine if a user's profile picture
should be displayed, but which we don't actually implement, was
inadvertently removed from the connected `UserDetail` component when
viewing a proxy, which caused an NPE, which made checkout-as-proxy
impossible to use.

IOW, a prop for a setting we _don't_ use broke a feature we _do_. Oy.

Restored the setting, and added some tests.

Refs [UICHKOUT-614](https://issues.folio.org/browse/UICHKOUT-614)