### PR TITLE
UICHKOUT-549: Add confirmation modal for Lost and paid items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Upgrade to `stripes` `4.0`, `react-intl` `4.5`. Refs STRIPES-672.
 * Upgrade to `react-intl-safe-html` `2.0`. Refs STRIPES-672.
-* Use local file as a profile placeholder. Refs UICHKOUT-624
+* Use local file as a profile placeholder. Refs UICHKOUT-624.
+* Add confirmation modal for Lost and paid items. Refs UICHKOUT-549.
 
 ## [3.1.0] (IN PROGRESS)
 

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -281,7 +281,7 @@ class ModalManager extends React.Component {
 
     return (
       <ConfirmationModal
-        id="test-confirm-withdrawn-modal"
+        id="test-confirm-status-modal"
         open={showStatusModal}
         item={checkedoutItem}
         heading={<FormattedMessage id={heading} />}

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -81,9 +81,12 @@ class ModalManager extends React.Component {
 
   shouldStatusModalBeShown = () => {
     const { checkedoutItem } = this.state;
-    const status = checkedoutItem?.status?.name;
 
-    return status === statuses.MISSING || status === statuses.WITHDRAWN;
+    return [
+      statuses.LOST_AND_PAID,
+      statuses.MISSING,
+      statuses.WITHDRAWN,
+    ].includes(checkedoutItem?.status?.name);
   }
 
   shouldCheckoutNoteModalBeShown = () => {
@@ -259,15 +262,18 @@ class ModalManager extends React.Component {
     const messageId = checkedoutItem.discoverySuppress ?
       'ui-checkout.confirmStatusModal.suppressedMessage' :
       'ui-checkout.confirmStatusModal.notSuppressedMessage';
+    values.status = checkedoutItem?.status?.name;
+
     let heading;
     switch (checkedoutItem?.status?.name) {
+      case statuses.LOST_AND_PAID:
+        heading = 'ui-checkout.confirmStatusModal.heading.lostAndPaid';
+        break;
       case statuses.MISSING:
         heading = 'ui-checkout.confirmStatusModal.heading.missing';
-        values.status = statuses.MISSING;
         break;
       case statuses.WITHDRAWN:
         heading = 'ui-checkout.confirmStatusModal.heading.withdrawn';
-        values.status = statuses.WITHDRAWN;
         break;
       default:
         break;

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,7 @@ export const OVERRIDABLE_ERROR_MESSAGES = [ITEM_NOT_LOANABLE];
 
 export const statuses = {
   CHECK_OUT: 'Check out',
+  LOST_AND_PAID: 'Lost and paid',
   MISSING: 'Missing',
   WITHDRAWN: 'Withdrawn',
 };

--- a/test/bigtest/interactors/check-out.js
+++ b/test/bigtest/interactors/check-out.js
@@ -52,12 +52,12 @@ export default interactor(class CheckOutInteractor {
   errorModal = new ErrorModal();
   overrideModal = new OverrideModal();
   checkoutNoteModal = new CheckoutNoteModalInteractor();
-  confirmWithdrawnModal = new ConfirmModalInteractor('#test-confirm-withdrawn-modal');
+  confirmStatusModal = new ConfirmModalInteractor('#test-confirm-status-modal');
   items = collection('#list-items-checked-out [class*=mclRowContainer---] [class^="mclRow---"]', Item);
   itemsCount = count('#list-items-checked-out [class*=mclRowContainer---] [class^="mclRow---"]', Item);
 
   patronErrorPresent = isPresent('#section-patron [class*=error---]');
-  confirmWithdrawnModalPresent = isPresent('#test-confirm-withdrawn-modal');
+  confirmStatusModalPresent = isPresent('#test-confirm-status-modal');
   patronDetailIsPresent = isPresent('#patron-detail');
   proxyDetailIsPresent = isPresent('#proxy-detail');
 

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -66,6 +66,7 @@
   "multipieceModal.item.descriptionOfPieces": "Description of pieces",
   "multipieceModal.item.numberOfMissingPieces": "Number of missing pieces",
   "multipieceModal.item.descriptionOfmissingPieces": "Description of missing pieces",
+  "confirmStatusModal.heading.lostAndPaid": "Check out lost and paid item?",
   "confirmStatusModal.heading.missing": "Check out missing item?",
   "confirmStatusModal.heading.withdrawn": "Check out withdrawn item?",
   "confirmStatusModal.notSuppressedMessage": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>{status}</strong>.",


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-549

Before checking out an item with status Lost and paid, confirm with the user.

<img width="1402" alt="Screen Shot 2020-06-09 at 4 42 32 PM" src="https://user-images.githubusercontent.com/1322242/84197782-81440880-aa70-11ea-8b52-9f11ef34eb4f.png">

This includes a little bit of test refactoring inspired by @SergiyVSergiyenko 's work in ui-requests.