### PR TITLE
CIRCSTORE-215 use == for more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 4.1.0 (IN PROGRESS)
+
+* Query with `==` to use indexes, when possible, for better efficiency. Refs CIRCSTORE-215.
+
 ## [4.0.0](https://github.com/folio-org/ui-checkout/tree/v4.0.0) (2020-06-15)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v3.0.0...v4.0.0)
 

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -43,7 +43,7 @@ class CheckOut extends React.Component {
     checkoutSettings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module=CHECKOUT and configName=other_settings)',
+      path: 'configurations/entries?query=(module==CHECKOUT and configName==other_settings)',
     },
     patrons: {
       type: 'okapi',
@@ -55,7 +55,7 @@ class CheckOut extends React.Component {
     settings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module=USERS and configName=profile_pictures)',
+      path: 'configurations/entries?query=(module==USERS and configName==profile_pictures)',
     },
     loans: {
       type: 'okapi',
@@ -66,7 +66,7 @@ class CheckOut extends React.Component {
     manualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=userId=%{activeRecord.patronId}',
+      path: 'manualblocks?query=userId==%{activeRecord.patronId}',
       DELETE: {
         path: 'manualblocks/%{activeRecord.blockId}',
       },

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -43,7 +43,10 @@ class UserDetail extends React.Component {
     openRequests: {
       type: 'okapi',
       throwErrors: false,
-      path: 'circulation/requests?query=(requesterId==!{user.id} and status==Open)&limit=100',
+      // yes, `status=Open` not `status==Open` becuase in fact `status` has
+      // values like `Open - Awaiting pickup` and `Open - In transit` and we
+      // want to retrieve all "open" statuses.
+      path: 'circulation/requests?query=(requesterId==!{user.id} and status=Open)&limit=100',
     },
   });
 

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -28,22 +28,22 @@ class UserDetail extends React.Component {
   static manifest = Object.freeze({
     patronGroups: {
       type: 'okapi',
-      path: 'groups?query=(id=!{user.patronGroup})',
+      path: 'groups?query=(id==!{user.patronGroup})',
       records: 'usergroups',
     },
     openLoansCount: {
       type: 'okapi',
-      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=1',
+      path: 'circulation/loans?query=(userId==!{user.id} and status.name<>Closed)&limit=1',
     },
     openAccounts: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=(userId=!{user.id} and status.name<>Closed)&limit=100',
+      path: 'accounts?query=(userId==!{user.id} and status.name<>Closed)&limit=100',
     },
     openRequests: {
       type: 'okapi',
       throwErrors: false,
-      path: 'circulation/requests?query=(requesterId=!{user.id} and status=Open)&limit=100',
+      path: 'circulation/requests?query=(requesterId==!{user.id} and status==Open)&limit=100',
     },
   });
 

--- a/src/util.js
+++ b/src/util.js
@@ -41,7 +41,7 @@ export function buildIdentifierQuery(patron, idents) {
 
 export function buildRequestQuery(requesterId, servicePointId) {
   return `(requesterId==${requesterId} and
-    pickupServicePointId=${servicePointId} and
+    pickupServicePointId==${servicePointId} and
     status=="Open - Awaiting pickup")`;
 }
 


### PR DESCRIPTION
Use `==` instead of `=` when possible to take advantage of table indexes
and therefore issue more efficient queries.

Refs [CIRCSTORE-215](https://issues.folio.org/browse/CIRCSTORE-215)