### PR TITLE
Revert "CIRCSTORE-215 use == for more efficient queries"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for ui-checkout
 
-## 4.1.0 (IN PROGRESS)
-
-* Query with `==` to use indexes, when possible, for better efficiency. Refs CIRCSTORE-215.
-
 ## [4.0.0](https://github.com/folio-org/ui-checkout/tree/v4.0.0) (2020-06-15)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v3.0.0...v4.0.0)
 

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -43,7 +43,7 @@ class CheckOut extends React.Component {
     checkoutSettings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module==CHECKOUT and configName==other_settings)',
+      path: 'configurations/entries?query=(module=CHECKOUT and configName=other_settings)',
     },
     patrons: {
       type: 'okapi',
@@ -55,7 +55,7 @@ class CheckOut extends React.Component {
     settings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module==USERS and configName==profile_pictures)',
+      path: 'configurations/entries?query=(module=USERS and configName=profile_pictures)',
     },
     loans: {
       type: 'okapi',
@@ -66,7 +66,7 @@ class CheckOut extends React.Component {
     manualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=userId==%{activeRecord.patronId}',
+      path: 'manualblocks?query=userId=%{activeRecord.patronId}',
       DELETE: {
         path: 'manualblocks/%{activeRecord.blockId}',
       },

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -28,25 +28,22 @@ class UserDetail extends React.Component {
   static manifest = Object.freeze({
     patronGroups: {
       type: 'okapi',
-      path: 'groups?query=(id==!{user.patronGroup})',
+      path: 'groups?query=(id=!{user.patronGroup})',
       records: 'usergroups',
     },
     openLoansCount: {
       type: 'okapi',
-      path: 'circulation/loans?query=(userId==!{user.id} and status.name<>Closed)&limit=1',
+      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=1',
     },
     openAccounts: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=(userId==!{user.id} and status.name<>Closed)&limit=100',
+      path: 'accounts?query=(userId=!{user.id} and status.name<>Closed)&limit=100',
     },
     openRequests: {
       type: 'okapi',
       throwErrors: false,
-      // yes, `status=Open` not `status==Open` becuase in fact `status` has
-      // values like `Open - Awaiting pickup` and `Open - In transit` and we
-      // want to retrieve all "open" statuses.
-      path: 'circulation/requests?query=(requesterId==!{user.id} and status=Open)&limit=100',
+      path: 'circulation/requests?query=(requesterId=!{user.id} and status=Open)&limit=100',
     },
   });
 

--- a/src/util.js
+++ b/src/util.js
@@ -41,7 +41,7 @@ export function buildIdentifierQuery(patron, idents) {
 
 export function buildRequestQuery(requesterId, servicePointId) {
   return `(requesterId==${requesterId} and
-    pickupServicePointId==${servicePointId} and
+    pickupServicePointId=${servicePointId} and
     status=="Open - Awaiting pickup")`;
 }
 


### PR DESCRIPTION
Reverts folio-org/ui-checkout#498

Not so fast! As noted in [PREF-62](https://issues.folio.org/browse/PERF-62), we haven't actually tested all these queries for performance improvements yet. There are really only two rules in performance optimizations: 

1. measure first
1. only change _one thing_

This PR breaks 'em both. 🤦 