### PR TITLE
CIRCSTORE-215 use == for more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 4.0.1 (IN PROGRESS)
+
+* Use `==` for more efficient queries. Refs CIRCSTORE-215, PERF-62.
+
 ## [4.0.0](https://github.com/folio-org/ui-checkout/tree/v4.0.0) (2020-06-15)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v3.0.0...v4.0.0)
 

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -43,7 +43,7 @@ class CheckOut extends React.Component {
     checkoutSettings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module=CHECKOUT and configName=other_settings)',
+      path: 'configurations/entries?query=(module==CHECKOUT and configName==other_settings)',
     },
     patrons: {
       type: 'okapi',
@@ -55,7 +55,7 @@ class CheckOut extends React.Component {
     settings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module=USERS and configName=profile_pictures)',
+      path: 'configurations/entries?query=(module==USERS and configName==profile_pictures)',
     },
     loans: {
       type: 'okapi',

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -28,12 +28,12 @@ class UserDetail extends React.Component {
   static manifest = Object.freeze({
     patronGroups: {
       type: 'okapi',
-      path: 'groups?query=(id=!{user.patronGroup})',
+      path: 'groups?query=(id==!{user.patronGroup})',
       records: 'usergroups',
     },
     openLoansCount: {
       type: 'okapi',
-      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=1',
+      path: 'circulation/loans?query=(userId==!{user.id} and status.name<>Closed)&limit=1',
     },
     openAccounts: {
       type: 'okapi',


### PR DESCRIPTION
Use `==` instead of `=` for more efficient (exact match) queries.

Refs [CIRCSTORE-215](https://issues.folio.org/browse/CIRCSTORE-215), [PERF-62](https://issues.folio.org/browse/PERF-62)