### PR TITLE
increment plugin-find-user to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 4.0.1 (IN PROGRESS)
+
+* Increment `@folio/plugin-find-user` to `v3.0` for `@folio/stripes` `v4` compatibility.
+
 ## [4.0.0](https://github.com/folio-org/ui-checkout/tree/v4.0.0) (2020-06-15)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v3.0.0...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "react-router-dom": "^4.0.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^2.0.0"
+    "@folio/plugin-find-user": "^3.0.0"
   },
   "resolutions": {
     "moment": "~2.24.0"


### PR DESCRIPTION
Increment `@folio/plugin-find-user` version to `^3` for
compatibility with `@folio/stripes` `4.0`.