### PR TITLE
PERF-62 use == for more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Checkout barcode CQL injection.  Fixes UICHKOUT-633.
 * Updated React-intl dependency to 4.7.2
+* Use `==` for more efficient queries. Refs PERF-62.
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -66,7 +66,7 @@ class CheckOut extends React.Component {
     manualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=userId=%{activeRecord.patronId}',
+      path: 'manualblocks?query=userId==%{activeRecord.patronId}',
       DELETE: {
         path: 'manualblocks/%{activeRecord.blockId}',
       },

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -38,12 +38,12 @@ class UserDetail extends React.Component {
     openAccounts: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=(userId=!{user.id} and status.name<>Closed)&limit=100',
+      path: 'accounts?query=(userId==!{user.id} and status.name<>Closed)&limit=100',
     },
     openRequests: {
       type: 'okapi',
       throwErrors: false,
-      path: 'circulation/requests?query=(requesterId=!{user.id} and status=Open)&limit=100',
+      path: 'circulation/requests?query=(requesterId==!{user.id} and status=Open)&limit=100',
     },
   });
 


### PR DESCRIPTION
Use `==` instead of `=` for more efficient queries.

Refs [PERF-62](https://issues.folio.org/browse/PERF-62)