### PR TITLE
UICHKOUT-641: Use right truncation operator to fetch user's open requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Checkout barcode CQL injection.  Fixes UICHKOUT-633.
 * Updated React-intl dependency to 4.7.2
 * Use `==` for more efficient queries. Refs PERF-62.
+* Use right truncation to fetch user's open request (UICHKOUT-641).
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -43,7 +43,7 @@ class UserDetail extends React.Component {
     openRequests: {
       type: 'okapi',
       throwErrors: false,
-      path: 'circulation/requests?query=(requesterId==!{user.id} and status=Open)&limit=100',
+      path: 'circulation/requests?query=(requesterId==!{user.id} and status=="Open*")&limit=100',
     },
   });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-641 - Use right truncation to fetch all open requests.

## Purpose

As per @julianladisch:

> The CQL query status = Open is most likely an error. It returns all statuses that contain the word Open including "Closed - was Open before" (if such an status were existing).
status == "Open *" is probably what is intended and matches statuses that start with Open – all open request of the tenant. The appropriate index for this is b-tree "index" and not "fullTextIndex".