### PR TITLE
UICHKOUT-639: Proxy borrower does not display on loan details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Checkout barcode CQL injection.  Fixes UICHKOUT-633.
 * Updated React-intl dependency to 4.7.2
 * Use `==` for more efficient queries. Refs PERF-62.
+* pass proxy borrower's barcode to checkout endpoint. Fixes UICHKOUT-639
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -83,6 +83,7 @@ class ScanItems extends React.Component {
     }),
 
     patron: PropTypes.object,
+    proxy: PropTypes.object,
     onSessionEnd: PropTypes.func.isRequired,
     settings: PropTypes.object,
     openBlockedModal: PropTypes.func,
@@ -196,14 +197,25 @@ class ScanItems extends React.Component {
   };
 
   getRequestData(barcode) {
-    const { stripes, patron } = this.props;
+    const { stripes, patron, proxy } = this.props;
     const servicePointId = get(stripes, 'user.user.curServicePoint.id', '');
+    let data;
+    if (Object.keys(proxy).length > 0) {
+      data = {
+        itemBarcode: barcode.trim(),
+        userBarcode: patron.barcode,
+        proxyUserBarcode: proxy.barcode,
+        servicePointId,
+      };
+    } else {
+      data = {
+        itemBarcode: barcode.trim(),
+        userBarcode: patron.barcode,
+        servicePointId,
+      };
+    }
 
-    return {
-      itemBarcode: barcode.trim(),
-      userBarcode: patron.barcode,
-      servicePointId,
-    };
+    return data;
   }
 
   checkout = (barcode) => {
@@ -230,7 +242,6 @@ class ScanItems extends React.Component {
 
   performAction(action, data) {
     this.setState({ loading: true, error: null });
-
     return action.POST(data)
       .then(this.fetchLoanPolicy)
       .then(this.addScannedItem)


### PR DESCRIPTION
This turned out to be a problem with ui-checkout.  The module
was not providing the barcode of the proxy borrower when it
issued the check-out request, so as far as the back-end was
concerned, there was no proxy borrower.  I fixed this by
making the module check for the presence of proxy borrower
data, and include the proxy borrower's barcode if it was
present.

refs: https://issues.folio.org/browse/UICHKOUT-639