### PR TITLE
UICHKOUT-644 ignore proxy when acting as self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Increase test coverage for automated patron blocks. Refs UICHKOUT-531.
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Create access to New fast add record template from Check out screen. Refs UICHKOUT-628.
+* Do not send proxy info when patron has a proxy but is acting as self. Fixes UICHKOUT-644.
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -497,7 +497,11 @@ class CheckOut extends React.Component {
 
     if (!isEmpty(selPatron)) {
       patron = selPatron;
-      proxy = patrons[0];
+
+      // configure a proxy user ONLY if the patron and selected patron differ.
+      // if those values match, the patron _has_ a proxy but is acting as self
+      // and therefore proxy shouldn't come into play here.
+      proxy = (patrons[0].id !== patron.id) ? patrons[0] : {};
     }
 
     return (


### PR DESCRIPTION
Previously, if a patron had a proxy relationship but was acting as self,
the checkout request object would include the patron's barcode in both
the `userBarcode` and `proxyUserBarcode` properties. Now, when acting as
self, the `proxyUserBarcode` property will be omitted.

Fixes [UICHKOUT-644](https://issues.folio.org/browse/UICHKOUT-644)