### PR TITLE
UICHKOUT-646: Fast add permission (Check out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* Added permission checking to fast add button. Fixes UICHKOUT-646
 * refactor of code fix for UICHKOUT-633
 * Checkout barcode CQL injection.  Fixes UICHKOUT-633.
 * Updated React-intl dependency to 4.7.2

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -15,7 +15,7 @@ import {
   Pane,
   Paneset,
 } from '@folio/stripes/components';
-import { Pluggable } from '@folio/stripes/core';
+import { Pluggable, IfPermission } from '@folio/stripes/core';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
@@ -541,11 +541,13 @@ class CheckOut extends React.Component {
             defaultWidth="65%"
             paneTitle={<FormattedMessage id="ui-checkout.scanItems" />}
             lastMenu={
-              <Pluggable
-                aria-haspopup="true"
-                type="create-inventory-records"
-                id="clickable-create-inventory-records"
-              />
+              <IfPermission perm="module.ui-plugin-create-inventory-records.enabled">
+                <Pluggable
+                  aria-haspopup="true"
+                  type="create-inventory-records"
+                  id="clickable-create-inventory-records"
+                />
+              </IfPermission>
             }
           >
             <this.connectedScanItems


### PR DESCRIPTION
This was very straightforward.  I just wrapped an
IfPermission around the button.  There are existing
checks happening elsewhere in the system that seem to
me to address the other requirements in this story,
such as ensuring only people with checkout permission
can access the form (they can't load the checkout
module at all anyway.)

Refs: https://issues.folio.org/browse/UICHKOUT-646