### PR TITLE
UICHKOUT-649 handle malformed timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Create access to New fast add record template from Check out screen. Refs UICHKOUT-628.
 * Do not send proxy info when patron has a proxy but is acting as self. Fixes UICHKOUT-644.
+* Handle malformed timestamps. Refs UICHKOUT-649.
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   FormattedMessage,
-  FormattedDate,
-  FormattedTime,
   injectIntl,
 } from 'react-intl';
-import { ConfirmationModal } from '@folio/stripes/components';
+import {
+  ConfirmationModal,
+  FormattedDate,
+  FormattedTime,
+} from '@folio/stripes/components';
 
 import CheckoutNoteModal from './components/CheckoutNoteModal';
 import MultipieceModal from './components/MultipieceModal';

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import {
-  FormattedDate,
   FormattedMessage,
 } from 'react-intl';
 
@@ -16,6 +15,7 @@ import {
   Col,
   KeyValue,
   Row,
+  FormattedDate,
 } from '@folio/stripes/components';
 
 import { getFullName } from '../../util';

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment';
 import React from 'react';
-import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
@@ -12,6 +12,8 @@ import {
   Icon,
   MultiColumnList,
   Tooltip,
+  FormattedDate,
+  FormattedTime,
 } from '@folio/stripes/components';
 
 const sortMap = {


### PR DESCRIPTION
Use the stripes-components versions of `<FormattedDate>` and
`<FormattedTime>` because they do not choke on the timestamps that are
provided by some backend modules.

Refs [UICHKOUT-649](https://issues.folio.org/browse/UICHKOUT-649), [STCOM-659](https://issues.folio.org/browse/STCOM-659)