### PR TITLE
UICHKOUT-644 better proxy handling

### DIFF
--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -36,8 +36,17 @@ import {
 } from './util';
 import css from './CheckOut.css';
 
+/**
+ * Check out items to patrons. Patrons may be proxies for others (i.e. patrons
+ * may have sponsors and the items will be checked out to the sponsor, not the
+ * proxy).
+ */
 class CheckOut extends React.Component {
   static manifest = Object.freeze({
+    // the "selected patron", i.e. the one chosen from the select-a-patron
+    // modal when the original patron has a sponsor and therefore may be
+    // checking out as the sponsor (selPatron and patron are different) or
+    // checkout out as self (selPatron and patron are the same)
     selPatron: { initialValue: {} },
     query: { initialValue: {} },
     scannedItems: { initialValue: [] },
@@ -232,21 +241,21 @@ class CheckOut extends React.Component {
     const manualPatronBlocks = get(resources, ['manualPatronBlocks', 'records'], []);
     const automatedPatronBlocks = get(resources, ['automatedPatronBlocks', 'records'], []);
     const prevManualBlocks = get(prevResources, ['manualPatronBlocks', 'records'], []);
-    const prevExpirated = prevManualBlocks.filter(p => moment(moment(p.expirationDate).format()).isSameOrBefore(moment().format()) && p.expirationDate) || [];
-    const expirated = manualPatronBlocks.filter(p => moment(moment(p.expirationDate).format()).isSameOrBefore(moment().format()) && p.expirationDate) || [];
+    const prevExpired = prevManualBlocks.filter(p => moment(moment(p.expirationDate).format()).isSameOrBefore(moment().format()) && p.expirationDate) || [];
+    const expired = manualPatronBlocks.filter(p => moment(moment(p.expirationDate).format()).isSameOrBefore(moment().format()) && p.expirationDate) || [];
 
-    if ((prevExpirated.length > 0 && expirated.length === 0) || !isEmpty(automatedPatronBlocks)) {
+    if ((prevExpired.length > 0 && expired.length === 0) || !isEmpty(automatedPatronBlocks)) {
       if (submitting) {
         // eslint-disable-next-line react/no-did-update-set-state
         this.setState({ submitting: false });
       }
     }
 
-    if ((expirated.length > 0 && !submitting) && isEmpty(automatedPatronBlocks)) {
+    if ((expired.length > 0 && !submitting) && isEmpty(automatedPatronBlocks)) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ submitting: true });
 
-      expirated.forEach(p => {
+      expired.forEach(p => {
         mutator.activeRecord.update({ blockId: p.id });
         mutator.manualPatronBlocks.DELETE({ id: p.id });
       });
@@ -492,16 +501,26 @@ class CheckOut extends React.Component {
     const scannedTotal = get(resources, ['scannedItems', 'length'], []);
     const selPatron = resources.selPatron;
     const { loading, blocked, requestsCount } = this.state;
-    let patron = patrons[0];
-    let proxy = selPatron;
 
+    let patron = patrons[0];
+    let proxy = {};
+
+    // handling for users with sponsors: if we have a selected-patron
+    // (i.e. the borrower chosen in the ProxyManager dialog), then
+    // patron (borrower) should receive the selected user and the
+    // proxy should receive the original patron. Note that this means
+    // patron and proxy may be assigned the same value (i.e. when a patron
+    // has sponsors but is acting-as-self).
+    //
+    // This is necessary for ViewPatron (and its subsidiary ProxyManager)
+    // because ProxyManager will prompt to select a user if its proxy prop
+    // is empty. Huh? You might think that when a patron is acting-as-self
+    // then proxy should be empty, but instead proxy must match patron.
+    // Otherwise, navigating away from checkout and back will cause
+    // ProxyManager to re-display its prompt.
     if (!isEmpty(selPatron)) {
       patron = selPatron;
-
-      // configure a proxy user ONLY if the patron and selected patron differ.
-      // if those values match, the patron _has_ a proxy but is acting as self
-      // and therefore proxy shouldn't come into play here.
-      proxy = (patrons[0].id !== patron.id) ? patrons[0] : {};
+      proxy = patrons[0];
     }
 
     return (

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -204,7 +204,9 @@ class ScanItems extends React.Component {
       userBarcode: patron.barcode,
       servicePointId,
     };
-    if (proxy?.barcode) {
+
+    // only include the proxy barcode if it differs from the patron barcode
+    if (proxy?.barcode && proxy.barcode !== patron.barcode) {
       data.proxyUserBarcode = proxy.barcode;
     }
     return data;


### PR DESCRIPTION
* `fuggle`, verb, transitive: to screw something up
* `defuggle`, verb, transitive: to think you understand the problem when
in fact you do not, causing you to implement a fix that papers over the
issue without actually resolving it.
* `undefuggle`, verb, transitive: to truly understand the problem and
why the original "fix" didn't take, and to actually resolve the issue.

I don't know when this problem was originally fuggled, but the crux is
that the checkout API rejects requests that contain the same barcode for
both patron and proxy. #527 defuggled this by clearing out the proxy
value when a patron had sponsors but was acting as self. The hidden
problem was that the ProxyManager isn't smart enough to hide when
its patron and proxy values match; if a patron has sponsors and proxy is
empty, it _always_ displays.

In other words, `<ProxyManager>` and `<ScanItems>` have different needs
for how their proxy props are handled. *<sigh>* The final fix here is to
revert #527 and then update `<ScanItems>` to ignore proxy when patron
and proxy match.

Fuggle, defuggle, undefuggle. Now you know.

Refs [UICHKOUT-644](https://issues.folio.org/browse/UICHKOUT-644)