### PR TITLE
UICHKOUT-650: Hide ScanFooter when fast add record plugin is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Create access to New fast add record template from Check out screen. Refs UICHKOUT-628.
 * Do not send proxy info when patron has a proxy but is acting as self. Fixes UICHKOUT-644.
+* Hide `ScanFooter` when fast add record plugin is open. Fixes UICHKOUT-650.
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -14,6 +14,7 @@ import {
   Icon,
   Pane,
   Paneset,
+  Button,
 } from '@folio/stripes/components';
 import { Pluggable } from '@folio/stripes/core';
 
@@ -205,7 +206,6 @@ class CheckOut extends React.Component {
     this.onPatronLookup = this.onPatronLookup.bind(this);
     this.selectPatron = this.selectPatron.bind(this);
     this.clearResources = this.clearResources.bind(this);
-    this.state = { loading: false, blocked: false };
     this.patronFormInputRef = React.createRef();
     this.patronFormRef = React.createRef();
     this.itemFormRef = React.createRef();
@@ -213,6 +213,9 @@ class CheckOut extends React.Component {
     this.shouldSubmitAutomatically = hasIn(location, 'state.patronBarcode') && hasIn(location, 'state.itemBarcode');
     this.state = {
       submitting: false,
+      loading: false,
+      blocked: false,
+      showNewFastAddModal: false,
     };
   }
 
@@ -479,6 +482,12 @@ class CheckOut extends React.Component {
     this.props.history.push(viewUserPath);
   }
 
+  toggleNewFastAddModal = () => {
+    this.setState((state) => {
+      return { showNewFastAddModal: !state.showNewFastAddModal };
+    });
+  }
+
   render() {
     const {
       resources,
@@ -500,7 +509,12 @@ class CheckOut extends React.Component {
     const patronBlocks = concat(automatedPatronBlocks, manualPatronBlocks);
     const scannedTotal = get(resources, ['scannedItems', 'length'], []);
     const selPatron = resources.selPatron;
-    const { loading, blocked, requestsCount } = this.state;
+    const {
+      loading,
+      blocked,
+      requestsCount,
+      showNewFastAddModal,
+    } = this.state;
 
     let patron = patrons[0];
     let proxy = {};
@@ -560,11 +574,13 @@ class CheckOut extends React.Component {
             defaultWidth="65%"
             paneTitle={<FormattedMessage id="ui-checkout.scanItems" />}
             lastMenu={
-              <Pluggable
-                aria-haspopup="true"
-                type="create-inventory-records"
-                id="clickable-create-inventory-records"
-              />
+              <Button
+                data-test-add-inventory-records
+                marginBottom0
+                onClick={this.toggleNewFastAddModal}
+              >
+                <FormattedMessage id="ui-checkout.fastAddLabel" />
+              </Button>
             }
           >
             <this.connectedScanItems
@@ -607,6 +623,13 @@ class CheckOut extends React.Component {
             />
           }
           label={<FormattedMessage id="ui-checkout.awaitingPickupLabel" />}
+        />
+        <Pluggable
+          buttonVisible={false}
+          open={showNewFastAddModal}
+          type="create-inventory-records"
+          id="clickable-create-inventory-records"
+          onClose={this.toggleNewFastAddModal}
         />
       </div>
     );

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -600,7 +600,7 @@ class CheckOut extends React.Component {
             />
           </Pane>
         </Paneset>
-        {patrons.length > 0 &&
+        {patrons.length > 0 && !showNewFastAddModal &&
           <ScanFooter
             buttonId="clickable-done-footer"
             total={scannedTotal}

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -101,5 +101,7 @@
 
   "permission.overrideCheckOutByBarcode": "Check out: Override loans policy on check out by barcode",
   "permission.circulation": "Check out: Check out circulating items",
-  "permission.all": "Check out: All permissions"
+  "permission.all": "Check out: All permissions",
+
+  "fastAddLabel": "New fast add record"
 }


### PR DESCRIPTION
This PR refactors the way the ui-plugin-create-inventory-records is being displayed in a similar fashion to what @K-Felk did in  https://github.com/folio-org/ui-inventory/pull/1134.

This allows for displaying the plugin in the right place and also for controlling the ScanFooter.

https://issues.folio.org/browse/UICHKOUT-650

![fast-add](https://user-images.githubusercontent.com/63545/92493969-23d06c80-f1c3-11ea-92be-b416ef26e0da.gif)
