### PR TITLE
UICHKOUT-656: Update tooltip placement to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Create access to New fast add record template from Check out screen. Refs UICHKOUT-628.
 * Do not send proxy info when patron has a proxy but is acting as self. Fixes UICHKOUT-644.
 * Hide `ScanFooter` when fast add record plugin is open. Fixes UICHKOUT-650.
+* Updated `<Tooltip>` placement to 'top' to prevent the tooltip from rendering on top of the dropdown menu. Fixes UICHKOUT-656.
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -9,7 +9,7 @@ import {
   Button,
   Dropdown,
   DropdownMenu,
-  Icon,
+  IconButton,
   MultiColumnList,
   Tooltip,
 } from '@folio/stripes/components';
@@ -180,25 +180,25 @@ class ViewItem extends React.Component {
     const isCheckOutNote = element => element.noteType === 'Check out';
     const checkoutNotePresent = _.get(loan.item, ['circulationNotes'], []).some(isCheckOutNote);
 
-    const trigger = ({ getTriggerProps, triggerRef }) => {
-      return (
-        <>
-          <Button
+    const trigger = ({ getTriggerProps, triggerRef }) => (
+      <Tooltip
+        id="checkout-actions-tooltip"
+        text={<FormattedMessage id="ui-checkout.actions.moreDetails" />}
+        triggerRef={triggerRef}
+        placement="top"
+      >
+        {({ ref, ariaIds }) => (
+          <IconButton
             {...getTriggerProps()}
-            buttonStyle="hover dropdownActive"
-            aria-labelledby="checkout-actions-tooltip-text"
+            aria-labelledby={ariaIds.text}
             id="available-item-actions-button"
-          >
-            <Icon icon="ellipsis" size="large" />
-          </Button>
-          <Tooltip
-            id="checkout-actions-tooltip"
-            text={<FormattedMessage id="ui-checkout.actions.moreDetails" />}
-            triggerRef={triggerRef}
+            icon="ellipsis"
+            size="medium"
+            ref={ref}
           />
-        </>
-      );
-    };
+        )}
+      </Tooltip>
+    );
 
     const menu = ({ onToggle }) => {
       return (


### PR DESCRIPTION
Updated `<Tooltip>` implementation and updated tooltip placement to 'top' to prevent the tooltip from rendering on top of the dropdown menu. Fixes [UICHKOUT-656](https://issues.folio.org/browse/UICHKOUT-656).

## Before
![image](https://user-images.githubusercontent.com/640976/92598701-72f0cd00-f2a9-11ea-92dd-858e607cdb34.png)

## After
![image](https://user-images.githubusercontent.com/640976/92598633-5e143980-f2a9-11ea-898a-407e0a4bde25.png)
