### PR TITLE
UICHKOUT-643: increment @folio/stripes to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* upgraded some dependencies and tweaked some testing settings.  Addresses UICHKOUT-643
 * refactor of code fix for UICHKOUT-633
 * Checkout barcode CQL injection.  Fixes UICHKOUT-633.
 * Updated React-intl dependency to 4.7.2

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-dom": "^16.5.0",
     "react-intl": "^4.7.2",
     "react-redux": "^5.0.7",
-    "react-router-dom": "^4.0.0",
+    "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.2.2"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^3.0.0",
+    "@folio/plugin-find-user": "^4.0.0",
     "@folio/plugin-create-inventory-records": "^1.0.0"
   },
   "resolutions": {

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -110,7 +110,10 @@ export default function config() {
     if (request.queryParams.query) {
       return requests.all();
     } else {
-      return [];
+      return {
+        'requests' : [],
+        'totalRecords' : 0
+      };
     }
   });
 


### PR DESCRIPTION
It looks like this module has been using
stripes five in both testing and production.
I did update react-router-dom
to 5.2, and fixed an unrelated problem that
was causing some errors to pop up during testing.

refs: https://issues.folio.org/browse/UICHKOUT-643