### PR TITLE
Apply MCL column width hints API so columns can shrink to fit content.

### DIFF
--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -26,12 +26,12 @@ const sortMap = {
 const visibleColumns = ['no', 'Barcode', 'title', 'loanPolicy', 'dueDate', 'Time', ' '];
 
 const columnWidths = {
-  'Barcode': 140,
-  'title': 180,
-  'loanPolicy': 150,
-  'dueDate': 90,
-  'Time': 75,
-  ' ': 75,
+  'Barcode': { max: 140 },
+  'title': { max: 180 },
+  'loanPolicy': { max: 150 },
+  'dueDate': { max: 90 },
+  'Time': { max: 75 },
+  ' ': { max: 75 },
 };
 
 class ViewItem extends React.Component {
@@ -315,6 +315,7 @@ class ViewItem extends React.Component {
     return (
       <>
         <MultiColumnList
+          key={contentData.length}
           id="list-items-checked-out"
           visibleColumns={visibleColumns}
           columnMapping={this.columnMapping}


### PR DESCRIPTION
Citing https://issues.folio.org/browse/STRIPES-693

The new MCL column-width hint API allows you to set a maximum value - if the column can be rendered smaller it will be.

Additionally, i marked the MultiColumnList instance with a `key` prop so that if multiple items are added to the list, the width will refresh.

## Before:
![Check-out-before](https://user-images.githubusercontent.com/20704067/92958941-b9246880-f430-11ea-8887-5ad93b3a1d2d.png)

## After
![Check-out-updated](https://user-images.githubusercontent.com/20704067/92959044-d1948300-f430-11ea-8205-73562aaec2da.png)
