### PR TITLE
STRIPES-694 react-intl v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Do not send proxy info when patron has a proxy but is acting as self. Fixes UICHKOUT-644.
 * Hide `ScanFooter` when fast add record plugin is open. Fixes UICHKOUT-650.
 * Handle malformed timestamps. Refs UICHKOUT-649.
+* Increment `react-intl` to `v5` as part of the `@folio/stripes` `v5` update. Refs STRIPES-694.
 
 ## [4.0.1](https://github.com/folio-org/ui-checkout/tree/v4.0.1) (2020-06-19)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.0...v4.0.1)

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "mocha": "^5.2.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-intl": "^4.7.2",
+    "react-intl": "^5.8.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
@@ -124,7 +124,7 @@
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.8.0",
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Upgrade `react-intl` to `v5` since that is part of `@folio/stripes`
`v5`.

Refs [STRIPES-694](https://issues.folio.org/browse/STRIPES-694)