### PR TITLE
UICHKOUT-666 stretch the OverrideModal's height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 5.0.1 IN PROGRESS
+
+* Make way for `<Datepicker>` in the loan-policy override modal. Refs UICHKOUT-666.
+
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)
 

--- a/src/components/OverrideModal/OverrideModal.js
+++ b/src/components/OverrideModal/OverrideModal.js
@@ -124,6 +124,10 @@ function OverrideModal(props) {
           </Row>
         </Col>
       </form>
+      <br />
+      <br />
+      <br />
+      <br />
     </Modal>
   );
 }

--- a/test/bigtest/network/scenarios/manualPatronBlocks.js
+++ b/test/bigtest/network/scenarios/manualPatronBlocks.js
@@ -1,3 +1,4 @@
+import faker from 'faker';
 import { manualBlockMessage } from '../../constants';
 
 export default function patronBlocks(server) {
@@ -9,7 +10,7 @@ export default function patronBlocks(server) {
         'desc': manualBlockMessage,
         'staffInformation': 'Last 3 have bounced back and the letter we sent was returned to us.',
         'patronMessage': 'Please contact the Main Library to update your contact information.',
-        'expirationDate': '2020-10-23T00:00:00Z',
+        'expirationDate': faker.date.future().toISOString(),
         'borrowing': true,
         'renewals': true,
         'requests': true,


### PR DESCRIPTION
How gross is this hack? Let me count the ways.
It's gross by using breaks to set the height
So `<Datepicker>` will render full, in-sight
Instead of clipping first or final days.
`usePortal` pops it out, but sets its place
From _modal_'s `y` position, hardly right,
And so ensues a render offset fight.
It's gross but so so simple, earning praise?
It's gross and leaves a rake to later bruise
Oneself by all who place a month with faith
That it will show, unclipp'd, no edge to lose.
You'll fix the stripes-component? Hold my breath
I'll not. There, CSS collects its dues.
You love my gross fix. It's simple. Like death.

Refs [UICHKOUT-666](https://issues.folio.org/browse/UICHKOUT-666)