### PR TITLE
UICHKOUT-668 replace hardcoded date in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 5.0.1 IN PROGRESS
+
+* Do not use hard-coded dates in unit tests. Refs UICHKOUT-668.
+
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)
 

--- a/test/bigtest/network/scenarios/manualPatronBlocks.js
+++ b/test/bigtest/network/scenarios/manualPatronBlocks.js
@@ -1,3 +1,4 @@
+import faker from 'faker';
 import { manualBlockMessage } from '../../constants';
 
 export default function patronBlocks(server) {
@@ -9,7 +10,7 @@ export default function patronBlocks(server) {
         'desc': manualBlockMessage,
         'staffInformation': 'Last 3 have bounced back and the letter we sent was returned to us.',
         'patronMessage': 'Please contact the Main Library to update your contact information.',
-        'expirationDate': '2020-10-23T00:00:00Z',
+        'expirationDate': faker.date.future().toISOString(),
         'borrowing': true,
         'renewals': true,
         'requests': true,


### PR DESCRIPTION
A hard-coded block-expiration date in a unit test prevented that test
from running successfully after that date.

Refs [UICHKOUT-668](https://issues.folio.org/browse/UICHKOUT-668)