### PR TITLE
UICHKOUT-664 move moment to peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "inflected": "^2.0.4",
     "miragejs": "^0.1.40",
     "mocha": "^5.2.0",
+    "moment": "^2.29.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^5.8.0",
@@ -115,7 +116,6 @@
     "final-form": "^4.19.1",
     "inactivity-timer": "^1.0.0",
     "lodash": "^4.17.4",
-    "moment": "~2.24.0",
     "prop-types": "^15.6.0",
     "react-audio-player": "^0.9.0",
     "react-final-form": "^6.4.0",
@@ -123,6 +123,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
+    "moment": "^2.29.0",
     "react": "*",
     "react-intl": "^5.8.0",
     "react-router-dom": "^5.2.0"
@@ -130,8 +131,5 @@
   "optionalDependencies": {
     "@folio/plugin-find-user": "^4.0.0",
     "@folio/plugin-create-inventory-records": "^1.0.0"
-  },
-  "resolutions": {
-    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Move `moment` to a peer dependency so it can be correctly provided by
the platform in a version compatible with all other modules.

Refs [UICHKOUT-664](https://issues.folio.org/browse/UICHKOUT-664)