### PR TITLE
UICHKOUT-513 restore item-list sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Do not use hard-coded dates in unit tests. Refs UICHKOUT-668.
 * Make room for `<Datepicker>` in the loan-policy override modal. Refs UICHKOUT-666.
 * Check out permissions: refinements. Refs UICHKOUT-622.
+* Restore sortability of charged items table. Refs UICHKOUT-513.
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -25,14 +25,14 @@ const sortMap = {
   time: loan => moment(loan.dueDate).format('hh:mm a'),
 };
 
-const visibleColumns = ['no', 'Barcode', 'title', 'loanPolicy', 'dueDate', 'Time', ' '];
+const visibleColumns = ['no', 'barcode', 'title', 'loanPolicy', 'dueDate', 'time', ' '];
 
 const columnWidths = {
-  'Barcode': { max: 140 },
+  'barcode': { max: 140 },
   'title': { max: 180 },
   'loanPolicy': { max: 150 },
   'dueDate': { max: 90 },
-  'Time': { max: 75 },
+  'time': { max: 75 },
   ' ': { max: 75 },
 };
 
@@ -63,24 +63,26 @@ class ViewItem extends React.Component {
     };
 
     this.columnMapping = {
-      no: <FormattedMessage id="ui-checkout.numberAbbreviation" />,
-      title: <FormattedMessage id="ui-checkout.title" />,
-      loanPolicy: <FormattedMessage id="ui-checkout.loanPolicy" />,
+      barcode: <FormattedMessage id="ui-checkout.header.barcode" />,
       dueDate: <FormattedMessage id="ui-checkout.due.date" />,
       loanDate: <FormattedMessage id="ui-checkout.time" />,
+      loanPolicy: <FormattedMessage id="ui-checkout.loanPolicy" />,
+      no: <FormattedMessage id="ui-checkout.numberAbbreviation" />,
+      time: <FormattedMessage id="ui-checkout.time" />,
+      title: <FormattedMessage id="ui-checkout.title" />,
     };
   }
 
   onSort(e, meta) {
-    if (!sortMap[meta.alias]) return;
+    if (!sortMap[meta.name]) return;
 
     let {
       sortOrder,
       sortDirection,
     } = this.state;
 
-    if (sortOrder[0] !== meta.alias) {
-      sortOrder = [meta.alias, sortOrder[0]];
+    if (sortOrder[0] !== meta.name) {
+      sortOrder = [meta.name, sortOrder[0]];
       sortDirection = ['asc', sortDirection[0]];
     } else {
       const direction = (sortDirection[0] === 'desc') ? 'asc' : 'desc';
@@ -94,9 +96,9 @@ class ViewItem extends React.Component {
     return {
       'title': loan => (<div data-test-item-title>{_.get(loan, ['item', 'title'])}</div>),
       'loanPolicy': loan => (<div data-test-item-loan-policy>{_.get(loan, ['loanPolicy', 'name'])}</div>),
-      'Barcode': loan => (<div data-test-item-barcode>{_.get(loan, ['item', 'barcode'])}</div>),
+      'barcode': loan => (<div data-test-item-barcode>{_.get(loan, ['item', 'barcode'])}</div>),
       'dueDate': loan => (<div data-test-item-due-date><FormattedDate value={loan.dueDate} /></div>),
-      'Time': loan => (<div data-test-item-time><FormattedTime value={loan.dueDate} /></div>),
+      'time': loan => (<div data-test-item-time><FormattedTime value={loan.dueDate} /></div>),
       ' ': loan => (<div data-test-item-actions>{this.renderActions(loan)}</div>),
     };
   }

--- a/test/bigtest/tests/check-out-test.js
+++ b/test/bigtest/tests/check-out-test.js
@@ -396,13 +396,13 @@ describe('CheckOut', () => {
 
     beforeEach(async function () {
       user = this.server.create('user');
+      items = this.server.createList('item', itemsAmount, 'withLoan');
 
       await checkOut
         .fillPatronBarcode(user.barcode.toString())
         .clickPatronBtn()
         .whenUserIsLoaded();
 
-      items = this.server.createList('item', 2, 'withLoan');
 
       for (const [index, item] of items.entries()) {
         // eslint-disable-next-line no-await-in-loop
@@ -468,23 +468,38 @@ describe('CheckOut', () => {
       expect(checkOut.itemsCount).to.equal(3);
     });
 
-    // it('shows the first item first before sort', () => {
-    //   expect(checkOut.items(0).title.text).to.equal('B');
-    // });
+    it('shows the first item first before sort', () => {
+      expect(checkOut.items(0).title.text).to.equal('B');
+    });
 
-    // TODO: this test should be re-enabled once UICHKOUT-513 is fixed
-    // describe('clicking a header to sort', () => {
-    //   beforeEach(async function () {
-    //     const titleHeader = checkOut.itemList.headers(titleColumnIndex);
-    //     await titleHeader.click().whenListIsSorted(titleColumnIndex);
-    //   });
+    describe('clicking a header to sort', () => {
+      const titleColumnIndex = 2;
+      beforeEach(async function () {
+        const titleHeader = checkOut.itemList.headers(titleColumnIndex);
+        await titleHeader.click();
+      });
 
-    //   it('sorts the list of items alphabetically', () => {
-    //     expect(checkOut.itemList.headers(titleColumnIndex).isSortHeader).to.be.true;
-    //     expect(checkOut.itemList.rows(0).cells(titleColumnIndex).content).to.equal('A');
-    //     expect(checkOut.itemList.rows(2).cells(titleColumnIndex).content).to.equal('C');
-    //   });
-    // });
+      it('sorts the list of items alphabetically, ascending', () => {
+        expect(checkOut.itemList.headers(titleColumnIndex).isSortHeader).to.be.true;
+        expect(checkOut.itemList.rows(0).cells(titleColumnIndex).content).to.equal('A');
+        expect(checkOut.itemList.rows(2).cells(titleColumnIndex).content).to.equal('C');
+      });
+    });
+
+    describe('clicking a header twice to reverse sort, descending', () => {
+      const titleColumnIndex = 2;
+      beforeEach(async function () {
+        const titleHeader = checkOut.itemList.headers(titleColumnIndex);
+        await titleHeader.click();
+        await titleHeader.click();
+      });
+
+      it('sorts the list of items alphabetically', () => {
+        expect(checkOut.itemList.headers(titleColumnIndex).isSortHeader).to.be.true;
+        expect(checkOut.itemList.rows(0).cells(titleColumnIndex).content).to.equal('C');
+        expect(checkOut.itemList.rows(2).cells(titleColumnIndex).content).to.equal('A');
+      });
+    });
   });
 
   describe('asks for confirmation before checking out items with special status', () => {

--- a/translations/ui-checkout/en_US.json
+++ b/translations/ui-checkout/en_US.json
@@ -18,7 +18,7 @@
     "noItemsEntered": "No items have been entered yet",
     "numberAbbreviation": "No.",
     "loanPolicy": "Loan policy",
-    "dueDate": "Due Date",
+    "header.barcode": "Barcode",
     "patronGroup": "Patron Group",
     "active": "Active",
     "inactive": "Inactive",


### PR DESCRIPTION
It looks like the sort implementation got confused between column
aliases, which contain the displayed (i.e. i18n'ed) values, and column
names, which contain their code points. It's possible that before we had
correct i18n, the alias pointed to a simple string like `Barcode` rather
than a `<FormattedMessage id="barcode">` object that is meaningless
from a sorting point of view, as this was the original implementation
in PR #27.

Refs [UICHKOUT-513](https://issues.folio.org/browse/UICHKOUT-513)