### PR TITLE
Upgraded to create-inventory plugin v2.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-checkout
 
-## 5.0.1 IN PROGRESS
+## 5.1.0 IN PROGRESS
 
 * Do not use hard-coded dates in unit tests. Refs UICHKOUT-668.
 * Make room for `<Datepicker>` in the loan-policy override modal. Refs UICHKOUT-666.
@@ -9,6 +9,7 @@
 * Update due date when changed in the Check Out app. Refs UICHKOUT-647.
 * Replace 'ui-users.loans.edit' permisson with 'ui-users.loans.change-due-date' for changing due date.
 * Fix a label translation. Fixes UICHKOUT-675.
+* Upgraded to create-inventory plugin v2.0.0.
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -148,6 +148,6 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^4.0.0",
-    "@folio/plugin-create-inventory-records": "^1.0.0"
+    "@folio/plugin-create-inventory-records": "^2.0.0"
   }
 }

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -485,13 +485,6 @@ class CheckOut extends React.Component {
     this.props.history.push(viewUserPath);
   }
 
-  toggleNewFastAddModal = () => {
-    this.setState((state) => {
-      return { showNewFastAddModal: !state.showNewFastAddModal };
-    });
-  }
-
-
   render() {
     const {
       resources,
@@ -578,15 +571,19 @@ class CheckOut extends React.Component {
             defaultWidth="65%"
             paneTitle={<FormattedMessage id="ui-checkout.scanItems" />}
             lastMenu={
-              <IfPermission perm="ui-plugin-create-inventory-records.create">
-                <Button
-                  data-test-add-inventory-records
-                  marginBottom0
-                  onClick={this.toggleNewFastAddModal}
-                >
-                  <FormattedMessage id="ui-checkout.fastAddLabel" />
-                </Button>
-              </IfPermission>
+              <Pluggable
+                type="create-inventory-records"
+                id="clickable-create-inventory-records"
+                renderTrigger={({ onClick }) => (
+                  <Button
+                    data-test-add-inventory-records
+                    marginBottom0
+                    onClick={onClick}
+                  >
+                    <FormattedMessage id="ui-checkout.fastAddLabel" />
+                  </Button>
+                )}
+              />
             }
           >
             <this.connectedScanItems
@@ -629,13 +626,6 @@ class CheckOut extends React.Component {
             />
           }
           label={<FormattedMessage id="ui-checkout.awaitingPickupLabel" />}
-        />
-        <Pluggable
-          buttonVisible={false}
-          open={showNewFastAddModal}
-          type="create-inventory-records"
-          id="clickable-create-inventory-records"
-          onClose={this.toggleNewFastAddModal}
         />
       </div>
     );

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -16,10 +16,7 @@ import {
   Paneset,
   Button,
 } from '@folio/stripes/components';
-import {
-  IfPermission,
-  Pluggable,
-} from '@folio/stripes/core';
+import { Pluggable } from '@folio/stripes/core';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
@@ -218,7 +215,6 @@ class CheckOut extends React.Component {
       submitting: false,
       loading: false,
       blocked: false,
-      showNewFastAddModal: false,
     };
   }
 
@@ -510,7 +506,6 @@ class CheckOut extends React.Component {
       loading,
       blocked,
       requestsCount,
-      showNewFastAddModal,
     } = this.state;
 
     let patron = patrons[0];
@@ -603,7 +598,7 @@ class CheckOut extends React.Component {
             />
           </Pane>
         </Paneset>
-        {patrons.length > 0 && !showNewFastAddModal &&
+        {patrons.length > 0 &&
           <ScanFooter
             buttonId="clickable-done-footer"
             total={scannedTotal}


### PR DESCRIPTION
## Purpose
ui-plugin-create-inventory-records has a new major version v2 in development. [As part of that, I've added breaking changes in this PR.](https://github.com/folio-org/ui-plugin-create-inventory-records/pull/45) This PR handles those changes.

## Approach
- Remove IfPermission which is now being handled in the plugin.
- Switch to usage of `renderTrigger` instead of `buttonVisible` and a separate trigger render.
- Remove state variables since were now letting the plugin manage its visibility state 