### PR TITLE
UICHKOUT-669: Prevent check out for intellectual item status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Replace 'ui-users.loans.edit' permisson with 'ui-users.loans.change-due-date' for changing due date.
 * Fix a label translation. Fixes UICHKOUT-675.
 * Upgraded to create-inventory plugin v2.0.0.
+* Prevent check out when item with intellectual item status is scanned. Refs UICHKOUT-669.
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/test/bigtest/interactors/error-modal.js
+++ b/test/bigtest/interactors/error-modal.js
@@ -1,11 +1,13 @@
 import {
   interactor,
   scoped,
+  text,
 } from '@bigtest/interactor';
 
 @interactor class ErrorModal {
   static defaultScope = '[data-test-error-modal]';
 
+  content = text('[class^="modalContent---"] p');
   overrideButton = scoped('[data-test-override-button]');
   closeButton = scoped('[data-test-close-button]');
 }

--- a/test/bigtest/tests/check-out-test.js
+++ b/test/bigtest/tests/check-out-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import { Response } from 'miragejs';
 
 import { Button } from '@folio/stripes/components';
 
@@ -12,6 +13,11 @@ const itemModalStatuses = [
   'Missing',
   'Withdrawn',
   'Lost and paid',
+];
+
+// Assumed to be several non-checked out item statuses
+const nonCheckedOutItemStatuses = [
+  'Intellectual item',
 ];
 
 describe('CheckOut', () => {
@@ -190,6 +196,47 @@ describe('CheckOut', () => {
 
       it('should hide item list empty message during checkout', () => {
         expect(checkOut.itemListEmptyMessage).to.equal('');
+      });
+    });
+
+    nonCheckedOutItemStatuses.forEach(status => {
+      describe(`checking out item with status ${status}`, () => {
+        let item;
+        let errorMessage;
+
+        beforeEach(async function () {
+          const intellectualItem = this.server.create('item', {
+            status: {
+              name: status,
+            },
+          });
+
+          this.server.post('/circulation/check-out-by-barcode', (schema, request) => {
+            const params = JSON.parse(request.requestBody);
+            item = schema.items.findBy({ barcode: params.itemBarcode });
+            errorMessage = `${item.title} (${item.materialType.name}) (Barcode: ${item.barcode}) has the item status ${item.status.name} and cannot be checked out`;
+
+            return new Response(422, { 'Content-Type': 'application/json' }, {
+              errors: [{
+                message: errorMessage,
+                parameters: [{
+                  key : 'itemBarcode',
+                  value : params.itemBarcode,
+                }]
+              }]
+            });
+          });
+
+          await checkOut.checkoutItem(intellectualItem.barcode);
+        });
+
+        it('should show error modal', () => {
+          expect(checkOut.errorModal.isPresent).to.be.true;
+        });
+
+        it('should show error message', () => {
+          expect(checkOut.errorModal.content).to.equal(errorMessage);
+        });
       });
     });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-669

### Purpose
The prevention functionality was built on the BE. On FE, it was necessary to make sure that it works correctly and cover it with tests.

### Screenshot
![Screen Shot 2021-01-05 at 15 51 45](https://user-images.githubusercontent.com/49517355/103654036-0abbaa80-4f6e-11eb-8de1-75fcd50d7a12.png)
