### PR TITLE
UICHKOUT-690 dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.0.0",
     "final-form": "^4.19.1",
     "inactivity-timer": "^1.0.0",
     "lodash": "^4.17.4",
@@ -140,7 +140,7 @@
     "react-hot-loader": "^4.3.12"
   },
   "peerDependencies": {
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "moment": "^2.29.0",
     "react": "*",
     "react-intl": "^5.8.0",


### PR DESCRIPTION
The `@folio/stripes` peer dependency was out of sync with its dev-deps.

The `@folio/react-intl-safe-html` dependency was out of sync with the
version of `react-intl` in its peer-dep.

Refs [UICHKOUT-690](https://issues.folio.org/browse/UICHKOUT-690)