### PR TITLE
UICHKOUT-671: Add confirmation modal for 5 new item statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Prevent check out when item with intellectual item status is scanned. Refs UICHKOUT-669.
 * Update to stripes v6. Refs UICHKOUT-687.
 * Proxy not allowed to checkout items for sponsor if proxy has patron block. Refs UICHKOUT-673.
+* Show confirmation modal when scanning an item with one of the new statuses (Long missing, In process (non-requestable), Restricted, Unavailable, Unknown). Refs UICHKOUT-671.
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,9 +33,25 @@ export const OVERRIDABLE_ERROR_MESSAGES = [ITEM_NOT_LOANABLE];
 
 export const statuses = {
   CHECK_OUT: 'Check out',
+  IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
+  LONG_MISSING: 'Long missing',
   LOST_AND_PAID: 'Lost and paid',
   MISSING: 'Missing',
+  RESTRICTED: 'Restricted',
+  UNAVAILABLE: 'Unavailable',
+  UNKNOWN: 'Unknown',
   WITHDRAWN: 'Withdrawn',
+};
+
+export const statusMessages = {
+  'In process (non-requestable)': 'ui-checkout.statuses.inProcessNonRequestable',
+  'Long missing': 'ui-checkout.statuses.longMissing',
+  'Lost and paid': 'ui-checkout.statuses.lostAndPaid',
+  'Missing': 'ui-checkout.statuses.missing',
+  'Restricted': 'ui-checkout.statuses.restricted',
+  'Unavailable': 'ui-checkout.statuses.unavailable',
+  'Unknown': 'ui-checkout.statuses.unknown',
+  'Withdrawn': 'ui-checkout.statuses.withdrawn',
 };
 
 export default '';

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,13 @@
-import { get } from 'lodash';
+import {
+  get,
+  includes,
+} from 'lodash';
 
-import { defaultPatronIdentifier, patronIdentifierMap } from './constants';
+import {
+  defaultPatronIdentifier,
+  patronIdentifierMap,
+  statuses,
+} from './constants';
 
 // serialized object into http params
 export function toParams(obj) {
@@ -49,4 +56,17 @@ export function to(promise) {
   return promise
     .then(data => [null, data])
     .catch(err => [err]);
+}
+
+export function shouldStatusModalBeShown(item) {
+  return includes([
+    statuses.IN_PROCESS_NON_REQUESTABLE,
+    statuses.LONG_MISSING,
+    statuses.LOST_AND_PAID,
+    statuses.MISSING,
+    statuses.RESTRICTED,
+    statuses.UNAVAILABLE,
+    statuses.UNKNOWN,
+    statuses.WITHDRAWN,
+  ], item?.status?.name);
 }

--- a/test/bigtest/tests/check-out-test.js
+++ b/test/bigtest/tests/check-out-test.js
@@ -10,9 +10,14 @@ import CheckOutInteractor from '../interactors/check-out';
 import { loanPolicyId } from '../constants';
 
 const itemModalStatuses = [
-  'Missing',
-  'Withdrawn',
+  'In process (non-requestable)',
+  'Long missing',
   'Lost and paid',
+  'Missing',
+  'Restricted',
+  'Unavailable',
+  'Unknown',
+  'Withdrawn',
 ];
 
 // Assumed to be several non-checked out item statuses

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -65,9 +65,7 @@
   "multipieceModal.item.descriptionOfPieces": "Description of pieces",
   "multipieceModal.item.numberOfMissingPieces": "Number of missing pieces",
   "multipieceModal.item.descriptionOfmissingPieces": "Description of missing pieces",
-  "confirmStatusModal.heading.lostAndPaid": "Check out lost and paid item?",
-  "confirmStatusModal.heading.missing": "Check out missing item?",
-  "confirmStatusModal.heading.withdrawn": "Check out withdrawn item?",
+  "confirmStatusModal.heading": "Check out {status} item?",
   "confirmStatusModal.notSuppressedMessage": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>{status}</strong>.",
   "confirmStatusModal.suppressedMessage": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>{status}</strong> and is suppressed from discovery.",
   "note": "Note",
@@ -105,6 +103,15 @@
   "permission.viewLoans": "Check out: View loans",
   "permission.viewFeeFines": "Check out: View fees/fines",
   "permission.viewRequests": "Check out: View requests",
+
+  "statuses.missing": "Missing",
+  "statuses.withdrawn": "Withdrawn",
+  "statuses.lostAndPaid": "Lost and paid",
+  "statuses.restricted": "Restricted",
+  "statuses.inProcessNonRequestable": "In process (non-requestable)",
+  "statuses.longMissing": "Long missing",
+  "statuses.unavailable": "Unavailable",
+  "statuses.unknown": "Unknown",
 
   "fastAddLabel": "New fast add record"
 }


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKOUT-671

### Purpose
Before checking out an item with one of the statuses (`Long missing`, `In process (non-requestable)`, `Restricted`, `Unavailable`, `Unknown`), the user must confirm this.

### Screenshot
![Screen Shot 2021-02-08 at 17 34 33](https://user-images.githubusercontent.com/49517355/107241969-29610580-6a34-11eb-9b1f-d7267d613ec6.png)