### PR TITLE
UICHKOUT-686 Optional prefix to indicate scan readiness in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Increment `@folio/stripes-cli` to `v2`. Refs UICHKOUT-692.
 * Handle a full list of errors when check out fails. Refs UICHKOUT-679.
 * Item blocks: Allow for override when logged in user has credentials. Refs UICHKOUT-677.
+* Add support for optional `readyPrefix` property at the module level in stripes.config.js. If set, this prefix will be displayed in the title when the app is ready to receive a scanned item barcode. Implements UICHKOUT-686.
+
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -54,7 +54,7 @@ class ItemForm extends React.Component {
     super(props);
 
     this.barcodeEl = React.createRef();
-    this.readyPrefix = props.modules?.app?.filter(el => el.module === '@folio/checkout')?.[0]?.readyPrefix;
+    this.readyPrefix = props.modules?.app?.find(el => el.module === '@folio/checkout')?.readyPrefix;
     this.state = {
       overrideModalOpen: false,
       errors: [],

--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -12,6 +12,8 @@ import {
   TextField,
 } from '@folio/stripes/components';
 import {
+  TitleManager,
+  withModules,
   withStripes,
   stripesShape,
 } from '@folio/stripes/core';
@@ -34,6 +36,9 @@ class ItemForm extends React.Component {
       PropTypes.object
     ).isRequired,
     onClearCheckoutErrors: PropTypes.func,
+    modules: PropTypes.shape({
+      app: PropTypes.arrayOf(PropTypes.object),
+    }),
   };
 
   static defaultProps = {
@@ -49,6 +54,7 @@ class ItemForm extends React.Component {
     super(props);
 
     this.barcodeEl = React.createRef();
+    this.readyPrefix = props.modules?.app?.filter(el => el.module === '@folio/checkout')?.[0]?.readyPrefix;
     this.state = {
       overrideModalOpen: false,
       errors: [],
@@ -153,16 +159,20 @@ class ItemForm extends React.Component {
                 {placeholder => (
                   <FormattedMessage id="ui-checkout.itemId">
                     {ariaLabel => (
-                      <Field
-                        fullWidth
-                        name="item.barcode"
-                        component={TextField}
-                        aria-label={ariaLabel}
-                        id="input-item-barcode"
-                        placeholder={placeholder}
-                        inputRef={this.barcodeEl}
-                        validationEnabled={validationEnabled}
-                      />
+                      <TitleManager prefix={(this.readyPrefix && this.state.readyToScan) ? this.readyPrefix : undefined}>
+                        <Field
+                          fullWidth
+                          name="item.barcode"
+                          component={TextField}
+                          aria-label={ariaLabel}
+                          id="input-item-barcode"
+                          placeholder={placeholder}
+                          inputRef={this.barcodeEl}
+                          validationEnabled={validationEnabled}
+                          onFocus={this.readyPrefix ? () => this.setState({ readyToScan: true }) : undefined}
+                          onBlur={this.readyPrefix ? () => this.setState({ readyToScan: false }) : undefined}
+                        />
+                      </TitleManager>
                     )}
                   </FormattedMessage>
                 )}
@@ -206,4 +216,4 @@ class ItemForm extends React.Component {
 
 export default stripesFinalForm({
   navigationCheck: true,
-})(withStripes(ItemForm));
+})(withStripes(withModules(ItemForm)));


### PR DESCRIPTION
Adds support for an optional `readyPrefix` property at the module level in stripes.config.js. If set, this prefix will be displayed in the title when the app is ready to receive a scanned item barcode.