### PR TITLE
UICHKOUT-680: Remove unused endpoint and permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Increment `@folio/stripes-cli` to `v2`. Refs UICHKOUT-692.
 * Handle a full list of errors when check out fails. Refs UICHKOUT-679.
 * Item blocks: Allow for override when logged in user has credentials. Refs UICHKOUT-677.
+* Remove old override endpoint and permission. Refs UICHKOUT-688.
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -40,13 +40,6 @@
         "displayName": "UI: Check out module is enabled"
       },
       {
-        "permissionName": "ui-checkout.overrideCheckOutByBarcode",
-        "displayName": "Check out: Override loans policy on check out by barcode",
-        "subPermissions": [
-          "circulation.override-check-out-by-barcode.post"
-        ]
-      },
-      {
         "permissionName": "ui-checkout.circulation",
         "displayName": "Check out: Check out circulating items",
         "description": "Set of permissions needed to check out circulation items",
@@ -72,8 +65,7 @@
         "description": "Entire set of permissions needed to use Check out",
         "visible": true,
         "subPermissions": [
-          "ui-checkout.circulation",
-          "ui-checkout.overrideCheckOutByBarcode"
+          "ui-checkout.circulation"
         ]
       },
       {

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -33,12 +33,6 @@ class ScanItems extends React.Component {
       fetch: false,
       throwErrors: false,
     },
-    overrideCheckout: {
-      type: 'okapi',
-      path: 'circulation/override-check-out-by-barcode',
-      fetch: false,
-      throwErrors: false,
-    },
     items: {
       type: 'okapi',
       path: 'inventory/items',
@@ -62,9 +56,6 @@ class ScanItems extends React.Component {
         reset: PropTypes.func,
       }),
       checkout: PropTypes.shape({
-        POST: PropTypes.func,
-      }),
-      overrideCheckout: PropTypes.shape({
         POST: PropTypes.func,
       }),
       items: PropTypes.shape({

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -259,26 +259,4 @@ export default function config() {
       }
     );
   });
-
-  this.post('/circulation/override-check-out-by-barcode', (schema, request) => {
-    const parsedRequest = JSON.parse(request.requestBody);
-    const patron = schema.users.findBy({ barcode: parsedRequest.userBarcode });
-    const item = schema.items.findBy({ barcode: parsedRequest.itemBarcode });
-    return (
-      {
-        id: item.id,
-        userId: patron.id,
-        itemId: item.id,
-        status: {
-          name: 'Open'
-        },
-        loanDate: '2017-03-05T18:32:31Z',
-        dueDate: '2017-03-19T18:32:31.000+0000',
-        action: 'checkedout',
-        renewalCount: 0,
-        item,
-        loanPolicyId,
-      }
-    );
-  });
 }

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -98,7 +98,6 @@
   "item.block.overrided": "(Item limit overridden)",
   "actions.moreDetails": "Get more details about this item",
 
-  "permission.overrideCheckOutByBarcode": "Check out: Override loans policy on check out by barcode",
   "permission.circulation": "Check out: Check out circulating items",
   "permission.all": "Check out: All permissions",
   "permission.viewLoans": "Check out: View loans",


### PR DESCRIPTION
# Description
 - remove unused endpoint `POST /circulation/override-check-out-by-barcode`.
- remove unused permission `circulation.override-check-out-by-barcode.post`.
# Task
https://issues.folio.org/browse/UICHKOUT-680