### PR TITLE
UICHKOUT-695: Do not show specific error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Remove old override endpoint and permission. Refs UICHKOUT-680.
 * Patron blocks: Allow for override when logged in user has credentials. Refs UICHKOUT-688.
 * Add support for optional `readyPrefix` property at the module level in stripes.config.js. If set, this prefix will be displayed in the title when the app is ready to receive a scanned item barcode. Implements UICHKOUT-686.
+* Item level error at check out displays two errors that essentially mean the same thing. Refs UICHKOUT-695.
 
 ## [5.0.0](https://github.com/folio-org/ui-checkout/tree/v5.0.0) (2020-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v4.0.1...v5.0.0)

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -19,6 +19,7 @@ import {
 import {
   ITEM_NOT_LOANABLE,
   OVERRIDABLE_ERROR_MESSAGES,
+  ERRORS_TO_HIDE,
 } from '../../constants';
 import {
   getAllErrorMessages,
@@ -56,6 +57,10 @@ function ErrorModal(props) {
   const renderMessages = () => {
     return map(messages, (message, index) => {
       let notLoanableError = '';
+
+      if (ERRORS_TO_HIDE.includes(message)) {
+        return null;
+      }
 
       if (message === ITEM_NOT_LOANABLE) {
         const errorDetails = extractErrorDetails(errors, ITEM_NOT_LOANABLE);

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,10 @@ export const OVERRIDABLE_ERROR_MESSAGES = [
   MAX_ITEM_BLOCK_LIMIT,
 ];
 
+export const ERRORS_TO_HIDE = [
+  'Cannot check out item that already has an open loan'
+];
+
 export const statuses = {
   CHECK_OUT: 'Check out',
   IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',

--- a/test/bigtest/constants.js
+++ b/test/bigtest/constants.js
@@ -6,6 +6,7 @@ export const notLoanablePolicyName = 'Not loanable';
 export const notLoanablePolicyId = 'notLoanablePolicyId';
 export const notLoanableItemBarcode = 'notLoanableBarcode';
 export const checkoutErrorMessage = 'Item is already checked out';
+export const itemHasOpenLoanError = 'Cannot check out item that already has an open loan';
 export const blockedUserId1 = 'blockedUserId1';
 export const blockedUserId2 = 'blockedUserId2';
 export const blockedMessage = 'Patron has reached maximum allowed number of items charged out';

--- a/test/bigtest/network/scenarios/errorsList.js
+++ b/test/bigtest/network/scenarios/errorsList.js
@@ -4,6 +4,7 @@ import {
   notLoanablePolicyId,
   notLoanablePolicyName,
   checkoutErrorMessage,
+  itemHasOpenLoanError,
 } from '../../constants';
 
 export default (server) => {
@@ -28,6 +29,13 @@ export default (server) => {
           }, {
             'key': 'loanPolicyId',
             'value': notLoanablePolicyId
+          }]
+        },
+        {
+          'message': itemHasOpenLoanError,
+          'parameters': [{
+            'key': 'itemBarcode',
+            'value': notLoanableItemBarcode,
           }]
         }
       ]


### PR DESCRIPTION
# Description
Item level error at check out displays two errors that essentially mean the same thing
# Issue
https://issues.folio.org/browse/UICHKOUT-695
# Screenshot
**Before**
![image](https://user-images.githubusercontent.com/55694637/109316568-6e6aa180-7854-11eb-840c-5733f81e8097.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/109316490-5a26a480-7854-11eb-8e8b-c52fa96c6a7b.png)
