### PR TITLE
UICHKOUT-710 also support circulation 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.1.0] (IN PROGRESS)
 
 * Added ability to look-up patron by Custom Fields. Refs UICHKOUT-697
+* Also support `circulation` `10.0`. Refs UICHKOUT-710.
 
 ## [6.0.0](https://github.com/folio-org/ui-checkout/tree/v6.0.0) (2021-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v5.0.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "9.0",
+      "circulation": "9.0 10.0",
       "configuration": "2.0",
       "item-storage": "8.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
The only breaking change in `circulation` `10.0` was the removal of the
`override-check-out-by-barcode` which is not used here, hence continuing
to support `9.0`.

Refs [UICHKOUT-710](https://issues.folio.org/browse/UICHKOUT-710)