### PR TITLE
UICHKOUT-716: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added ability to look-up patron by Custom Fields. Refs UICHKOUT-697
 * Also support `circulation` `10.0`. Refs UICHKOUT-710.
 * For checkout alerts, use the audio theme specified in circulation settings; fall back to classic sounds if no theme is specified. Refs UICIRC-556.
+* Also support `circulation` `11.0`. Refs UICHKOUT-716.
 
 ## [6.0.0](https://github.com/folio-org/ui-checkout/tree/v6.0.0) (2021-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v5.0.0...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "9.0 10.0",
+      "circulation": "9.0 10.0 11.0",
       "configuration": "2.0",
       "item-storage": "8.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UICHKOUT-716