### PR TITLE
UICHKOUT-685 Added NotePopupModal to view patron page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added ability to look-up patron by Custom Fields. Refs UICHKOUT-697
 * Also support `circulation` `10.0`. Refs UICHKOUT-710.
 * For checkout alerts, use the audio theme specified in circulation settings; fall back to classic sounds if no theme is specified. Refs UICIRC-556.
+* Added `NotePopupModal` to view patron page. Refs UICHKOUT-685.
 
 ## [6.0.0](https://github.com/folio-org/ui-checkout/tree/v6.0.0) (2021-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v5.0.0...v6.0.0)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -15,6 +15,7 @@ import {
   Paneset,
   Button,
 } from '@folio/stripes/components';
+import { NotePopupModal } from '@folio/stripes/smart-components';
 import { Pluggable } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
@@ -728,6 +729,13 @@ class CheckOut extends React.Component {
             />
           }
           label={<FormattedMessage id="ui-checkout.awaitingPickupLabel" />}
+        />
+        <NotePopupModal
+          id="user-popup-note-modal"
+          domainName="users"
+          entityType="user"
+          popUpPropertyName="popUpOnCheckOut"
+          entityId={patron?.id}
         />
       </div>
     );


### PR DESCRIPTION
## Description
Added a `NotePopupModal`component that displays notes that are marked as pop-up notes

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/119004158-fb765000-b996-11eb-962f-d8100b4af8bf.png)

## Issues
[UICHKOUT-685](https://issues.folio.org/browse/UICHKOUT-685)