### PR TITLE
UICHKOUT-724 avoid *.all permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## 6.0.1 IN PROGRESS
+
+* Adjust `ui-checkout.circulation` permission set. Fixes UICHKOUT-724.
+
 ## [6.0.0](https://github.com/folio-org/ui-checkout/tree/v6.0.0) (2021-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v5.0.0...v6.0.0)
 

--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
         "description": "Set of permissions needed to check out circulation items",
         "visible": true,
         "subPermissions": [
-          "circulation.all",
-          "circulation-storage.all",
-          "configuration.all",
           "users.collection.get",
           "usergroups.collection.get",
           "proxiesfor.collection.get",
@@ -56,7 +53,12 @@
           "automated-patron-blocks.collection.get",
           "module.checkout.enabled",
           "inventory.items.collection.get",
-          "circulation.end-patron-action-session.post"
+          "circulation.end-patron-action-session.post",
+          "circulation.check-out-by-barcode.post",
+          "circulation.loans.collection.get",
+          "circulation.requests.collection.get",
+          "circulation-storage.loan-policies.collection.get",
+          "configuration.entries.collection.get"
         ]
       },
       {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
           "circulation.loans.collection.get",
           "circulation.requests.collection.get",
           "circulation-storage.loan-policies.collection.get",
-          "configuration.entries.collection.get"
+          "configuration.entries.collection.get",
+          "notes.collection.get.by.status"
         ]
       },
       {


### PR DESCRIPTION
Avoid using `*.all` permission sets as they are usually over-permissive. 

Refs UICHKOUT-724