### PR TITLE
UICHKOUT-727: Add extra permission checks for links loans, requests and accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [6.2.0] (IN PROGRESS)
 
 * Checking out to blocked patron doesn't offer override option. Refs UICHKOUT-725.
+* Add check for `ui-users.loans.view` permission in order to show link to loans in ui-users. Fixes UICHKOUT-727.
+* Add check for `ui-requests.view` permission in order to show link to requests in ui-requests. Fixes UICHKOUT-728.
+* Add check for `ui-users.accounts` permission in order to show link to fees/fines in ui-users. Fixes UICHKOUT-729.
 
 ## [6.1.0](https://github.com/folio-org/ui-checkout/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.0.0...v6.1.0)

--- a/src/components/UserDetail/Loans.js
+++ b/src/components/UserDetail/Loans.js
@@ -24,10 +24,7 @@ function Loans({
   user,
 }) {
   const renderOpenRequests = useMemo(() => {
-    if (!stripes.hasPerm('ui-users.requests.all,ui-requests.all')) return '-';
-
     const openRequestsCount = get(resources.openRequests, ['records', '0', 'totalRecords'], 0);
-
     const openRequestStatuses = [
       'Open - Not yet filled',
       'Open - Awaiting pickup',
@@ -36,9 +33,12 @@ function Loans({
     ]
       .map(status => `requestStatus.${status}`)
       .join(',');
-
     const openRequestsPath = `/requests?query=${user.barcode}&filters=${openRequestStatuses}&sort=Request date`;
-    if (stripes.hasPerm('ui-checkout.viewRequests')) {
+
+    // "ui-requests.view" doesn’t make ui-checkout dependent on ui-requests,
+    // but if ui-requests happens to be installed and the correct perms happen to be granted,
+    // then the requests link is present.
+    if (stripes.hasPerm('ui-checkout.viewRequests,ui-requests.view')) {
       return (
         <Link
           data-test-open-requests-count
@@ -48,6 +48,7 @@ function Loans({
         </Link>
       );
     }
+
     return openRequestsCount;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resources.openRequests, user.barcode]);
@@ -61,10 +62,18 @@ function Loans({
     return owed + parseFloat(remaining);
   }, 0);
   let openAccountsCount = parseFloat(owedAmount).toFixed(2);
-  if (owedAmount && stripes.hasPerm('ui-checkout.viewFeeFines')) {
+
+  // "ui-users.accounts" doesn’t make ui-checkout dependent on ui-users,
+  // but if ui-users happens to be installed and the correct perms happen to be granted,
+  // then the accounts link is present.
+  if (owedAmount && stripes.hasPerm('ui-checkout.viewFeeFines,ui-users.accounts')) {
     openAccountsCount = <Link to={openAccountsPath}>{openAccountsCount}</Link>;
   }
-  const openLoansLink = stripes.hasPerm('ui-checkout.viewLoans') ?
+
+  // "ui-users.loans.view" doesn’t make ui-checkout dependent on ui-users,
+  // but if ui-users happens to be installed and the correct perms happen to be granted,
+  // then the loan link is present.
+  const openLoansLink = stripes.hasPerm('ui-checkout.viewLoans,ui-users.loans.view') ?
     <Link to={openLoansPath}>{openLoansCount}</Link> : openLoansCount;
 
   return (

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -18,6 +18,11 @@ export default function config() {
     totalRecords: 0,
   });
 
+  this.get('/note-links/domain/users/type/user/id/:id', {
+    notes: [],
+    totalRecords: 0,
+  });
+
   this.get('/proxiesfor', {
     proxiesFor: [],
     totalRecords: 0,

--- a/test/bigtest/tests/check-out-test.js
+++ b/test/bigtest/tests/check-out-test.js
@@ -652,13 +652,16 @@ describe('CheckOut', () => {
 
       const item = this.server.create('item');
 
-      return this.visit({
+      this.visit({
         pathname: '/checkout',
         state: {
           itemBarcode: item.barcode,
           patronBarcode: user.barcode,
         }
       });
+
+      await checkOut.whenUserIsLoaded();
+      await checkOut.whenItemListIsPresent();
     });
 
     it('should display patron information', () => {


### PR DESCRIPTION
This PR takes care of 3 different tickets:

https://issues.folio.org/browse/UICHKOUT-727
https://issues.folio.org/browse/UICHKOUT-728
https://issues.folio.org/browse/UICHKOUT-729

It adds some extra permission checks in order to show links to loans, requests and accounts.

