### PR TITLE
UICHKOUT-720: Hide ScanFooter when fast add record plugin is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add check for `ui-users.loans.view` permission in order to show link to loans in ui-users. Fixes UICHKOUT-727.
 * Add check for `ui-requests.view` permission in order to show link to requests in ui-requests. Fixes UICHKOUT-728.
 * Add check for `ui-users.accounts` permission in order to show link to fees/fines in ui-users. Fixes UICHKOUT-729.
+* Hide `ScanFooter` when fast add record plugin is open. Fixes UICHKOUT-720.
 
 ## [6.1.0](https://github.com/folio-org/ui-checkout/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.0.0...v6.1.0)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -7,6 +7,7 @@ import {
   isEmpty,
   get,
   hasIn,
+  noop,
 } from 'lodash';
 
 import {
@@ -16,7 +17,7 @@ import {
   Button,
 } from '@folio/stripes/components';
 import { NotePopupModal } from '@folio/stripes/smart-components';
-import { Pluggable } from '@folio/stripes/core';
+import { Pluggable, IfPermission } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import PatronForm from './components/PatronForm';
@@ -316,6 +317,12 @@ class CheckOut extends React.Component {
     }
   }
 
+  toggleNewFastAddModal = () => {
+    this.setState((state) => {
+      return { showNewFastAddModal: !state.showNewFastAddModal };
+    });
+  }
+
   extractPatronBlocks = () => {
     const { resources } = this.props;
     const manualPatronBlocks = get(resources, ['manualPatronBlocks', 'records'], []);
@@ -603,6 +610,7 @@ class CheckOut extends React.Component {
       blocked,
       requestsCount,
       overrideModalOpen,
+      showNewFastAddModal,
     } = this.state;
     const isPatronBlockModalOpen = (blocked && isEmpty(patronBlockOverriddenInfo));
 
@@ -663,19 +671,15 @@ class CheckOut extends React.Component {
             defaultWidth="65%"
             paneTitle={<FormattedMessage id="ui-checkout.scanItems" />}
             lastMenu={
-              <Pluggable
-                type="create-inventory-records"
-                id="clickable-create-inventory-records"
-                renderTrigger={({ onClick }) => (
-                  <Button
-                    data-test-add-inventory-records
-                    marginBottom0
-                    onClick={onClick}
-                  >
-                    <FormattedMessage id="ui-checkout.fastAddLabel" />
-                  </Button>
-                )}
-              />
+              <IfPermission perm="ui-plugin-create-inventory-records.create">
+                <Button
+                  data-test-add-inventory-records
+                  marginBottom0
+                  onClick={this.toggleNewFastAddModal}
+                >
+                  <FormattedMessage id="ui-checkout.fastAddLabel" />
+                </Button>
+              </IfPermission>
             }
           >
             <this.connectedScanItems
@@ -696,7 +700,7 @@ class CheckOut extends React.Component {
             />
           </Pane>
         </Paneset>
-        {patrons.length > 0 &&
+        {patrons.length > 0 && !showNewFastAddModal &&
           <ScanFooter
             buttonId="clickable-done-footer"
             total={scannedTotal}
@@ -739,6 +743,13 @@ class CheckOut extends React.Component {
           entityType="user"
           popUpPropertyName="popUpOnCheckOut"
           entityId={patron?.id}
+        />
+        <Pluggable
+          type="create-inventory-records"
+          id="clickable-create-inventory-records"
+          open={showNewFastAddModal}
+          onClose={this.toggleNewFastAddModal}
+          renderTrigger={noop}
         />
       </div>
     );


### PR DESCRIPTION
 Hide `ScanFooter` when fast add record plugin is open.

https://issues.folio.org/browse/UICHKOUT-720

![fast-add](https://user-images.githubusercontent.com/63545/92493969-23d06c80-f1c3-11ea-92be-b416ef26e0da.gif)