### PR TITLE
UICHKOUT-731: Change modal layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add check for `ui-requests.view` permission in order to show link to requests in ui-requests. Fixes UICHKOUT-728.
 * Add check for `ui-users.accounts` permission in order to show link to fees/fines in ui-users. Fixes UICHKOUT-729.
 * Hide `ScanFooter` when fast add record plugin is open. Fixes UICHKOUT-720.
+* Date picker on circulation override cuts off after 4 weeks. Refs UICHKOUT-731.
 
 ## [6.1.0](https://github.com/folio-org/ui-checkout/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.0.0...v6.1.0)

--- a/src/components/OverrideModal/OverrideModal.css
+++ b/src/components/OverrideModal/OverrideModal.css
@@ -1,0 +1,3 @@
+.content {
+    min-height: 350px;
+}

--- a/src/components/OverrideModal/OverrideModal.js
+++ b/src/components/OverrideModal/OverrideModal.js
@@ -102,8 +102,8 @@ function OverrideModal(props) {
         data-test-override-modal-save-and-close
         marginBottom0
         buttonStyle="primary"
-        type="submit"
         disabled={!canBeSubmitted}
+        onClick={onSubmit}
       >
         <FormattedMessage id="ui-checkout.saveAndClose" />
       </Button>

--- a/src/components/OverrideModal/OverrideModal.js
+++ b/src/components/OverrideModal/OverrideModal.js
@@ -8,6 +8,7 @@ import {
   Button,
   Col,
   Modal,
+  ModalFooter,
   Row,
   TextArea,
 } from '@folio/stripes/components';
@@ -23,6 +24,7 @@ import {
   ITEM_NOT_LOANABLE,
   MAX_ITEM_BLOCK_LIMIT,
 } from '../../constants';
+import css from './OverrideModal.css';
 
 function OverrideModal(props) {
   const {
@@ -94,6 +96,27 @@ function OverrideModal(props) {
     </p>
   );
 
+  const footer = (
+    <ModalFooter>
+      <Button
+        data-test-override-modal-save-and-close
+        marginBottom0
+        buttonStyle="primary"
+        type="submit"
+        disabled={!canBeSubmitted}
+      >
+        <FormattedMessage id="ui-checkout.saveAndClose" />
+      </Button>
+      <Button
+        marginBottom0
+        onClick={closeOverrideModal}
+        data-test-override-modal-cancel
+      >
+        <FormattedMessage id="ui-checkout.cancel" />
+      </Button>
+    </ModalFooter>
+  );
+
   return (
     <Modal
       size="small"
@@ -102,10 +125,12 @@ function OverrideModal(props) {
       data-test-override-modal
       open
       label={getModalLabel()}
+      footer={footer}
       onClose={closeOverrideModal}
     >
       <form
         id="override-form"
+        className={itemIsNotLoanable ? css.content : null}
         onSubmit={onSubmit}
       >
         <Col xs={12}>
@@ -164,32 +189,6 @@ function OverrideModal(props) {
             value={comment}
             onChange={(e) => { setAdditionalInfo(e.target.value); }}
           />
-        </Col>
-        <Col xs={12}>
-          {itemIsNotLoanable &&
-            <>
-              <br />
-              <br />
-              <br />
-              <br />
-            </>
-          }
-          <Row end="xs">
-            <Button
-              onClick={closeOverrideModal}
-              data-test-override-modal-cancel
-            >
-              <FormattedMessage id="ui-checkout.cancel" />
-            </Button>
-            <Button
-              data-test-override-modal-save-and-close
-              buttonStyle="primary"
-              type="submit"
-              disabled={!canBeSubmitted}
-            >
-              <FormattedMessage id="ui-checkout.saveAndClose" />
-            </Button>
-          </Row>
         </Col>
       </form>
     </Modal>


### PR DESCRIPTION
# Description
* date picker on circulation override cuts off after 4 weeks
* make consistent modal footer with buttons located on the modal's edges
# Issue
https://issues.folio.org/browse/UICHKOUT-731
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/125069729-c4333e00-e0bf-11eb-90d3-1a8fdc1b2982.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/125069890-08264300-e0c0-11eb-8e67-de954e777aed.png)
