### PR TITLE
UICHKOUT-732 provide loan-date in ISO-8601 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add check for `ui-users.accounts` permission in order to show link to fees/fines in ui-users. Fixes UICHKOUT-729.
 * Hide `ScanFooter` when fast add record plugin is open. Fixes UICHKOUT-720.
 * Date picker on circulation override cuts off after 4 weeks. Refs UICHKOUT-731.
+* Always provide ISO-8601 dates in API requests. Refs UICHKOUT-732.
 
 ## [6.1.0](https://github.com/folio-org/ui-checkout/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.0.0...v6.1.0)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -272,7 +272,7 @@ class ScanItems extends React.Component {
     } = this.props;
     const checkoutData = {
       ...this.getRequestData(barcode),
-      loanDate: moment().utc().format(),
+      loanDate: moment().utc().toISOString(),
     };
 
     if (!isEmpty(patronBlockOverriddenInfo)) {


### PR DESCRIPTION
Replace `moment.format()` with `moment.toISOString()` because the
former does not guarantee the numbering system will be `Latn` (0-9,
Arabic numbers). Documentation not withstanding
(https://momentjs.com/docs/#/displaying/format/), what `.format()`
actually does is use the same tokens as for ISO-8601 but without
changing the numbering system. Thus, in a locale with a non-Latn
numbering system, e.g. where 0-9 are represented by a-j, a year-format
like `YYYY` could be returned as `cacb` instead of `2021`.

In fact, this is precisely what happens when the locale is set to `ar`
(Arabic, with a numbering system of Arabic-Hindi numerals, denoted
`Arab`, as opposed to Arabic numerals, denoted `Latn` ([don't ask](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem))).

Fixes [UICHKOUT-732](https://issues.folio.org/browse/UICHKOUT-732), refs [FOLIO-3208](https://issues.folio.org/browse/FOLIO-3208)