### PR TITLE
UICHKOUT-736 validate shapes to avoid NPEs on optional attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Date picker on circulation override cuts off after 4 weeks. Refs UICHKOUT-731.
 * Always provide ISO-8601 dates in API requests. Refs UICHKOUT-732.
 * Format numbers as numbers, not text. Refs UICHKOUT-734.
+* Validate shape of circulation notes before accessing their optional attributes. Refs UICHKOUT-736.
 
 ## [6.1.0](https://github.com/folio-org/ui-checkout/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.0.0...v6.1.0)

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -166,17 +166,14 @@ class ModalManager extends React.Component {
         note,
         date,
         source: {
-          personal: {
-            firstName,
-            lastName,
-          },
-        },
+          personal
+        } = {},
       } = checkoutNoteObject;
 
       return {
         note,
         date,
-        source: `${lastName}, ${firstName}`,
+        source: personal ? `${personal.lastName}, ${personal.firstName}` : '',
       };
     });
 


### PR DESCRIPTION
Validate shape of circulation notes before accessing their nest
attributes. Some attributes may be empty in notes created via
migrations.

Refs [UICHKOUT-736](https://issues.folio.org/browse/UICHKOUT-736)