### PR TITLE
UIU-2413: Always display fee/fine decimal places on Checkout page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [6.2.0] (IN PROGRESS)
 
+* Always display fee/fine decimal places on Checkout page. Fixes UIU-2413.
 * Checking out to blocked patron doesn't offer override option. Refs UICHKOUT-725.
 * Add check for `ui-users.loans.view` permission in order to show link to loans in ui-users. Fixes UICHKOUT-727.
 * Add check for `ui-requests.view` permission in order to show link to requests in ui-requests. Fixes UICHKOUT-728.

--- a/src/components/UserDetail/Loans.js
+++ b/src/components/UserDetail/Loans.js
@@ -50,7 +50,7 @@ function Loans({
         </Link>
       );
     }
-                                     
+
     return <FormattedNumber value={openRequestsCount} />;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resources.openRequests, user.barcode]);
@@ -73,11 +73,17 @@ function Loans({
       balanceOutstanding += (parseFloat(a.remaining));
     }
   });
-  let suspended = parseFloat(balanceSuspended).toFixed(2);
+  let suspended = <FormattedNumber
+    value={parseFloat(balanceSuspended).toFixed(2)}
+    minimumFractionDigits={2}
+  />;
   if (balanceSuspended > 0) {
     suspended = <Link data-test-suspended-account to={openAccountsPath}>{suspended}</Link>;
   }
-  let openAccountsCount = <FormattedNumber value={parseFloat(balanceOutstanding).toFixed(2)} />;
+  let openAccountsCount = <FormattedNumber
+    value={parseFloat(balanceOutstanding).toFixed(2)}
+    minimumFractionDigits={2}
+  />;
   if (owedAmount && stripes.hasPerm('ui-checkout.viewFeeFines,ui-users.accounts')) {
     openAccountsCount = <Link to={openAccountsPath}>{openAccountsCount}</Link>;
   }


### PR DESCRIPTION
## Purpose
We have requirement to always display fee/fine decimal places on Checkout page.

Also now number formatting for suspended fee/fine based on user locale is missing. **FormattedNumber** react component should be used to have such formatting.

## Approach
**FormattedNumber** react component does _not_ display decimal places if decimal places have zero values. For example if a value is "**10.00**" **FormattedNumber** will render just "**10**" without decimal places.

**FormattedNumber** has _minimumFractionDigits_ property which allows to always render as many decimal places as we need. In our case it should be 2.

## Screenshots
Before:
<img width="1274" alt="before" src="https://user-images.githubusercontent.com/47976677/132840656-31daf7a0-e365-4463-b2e4-0d9a291ef8a9.png">

After:
<img width="1266" alt="after" src="https://user-images.githubusercontent.com/47976677/132840673-5ffdd934-2072-41f5-9bc4-87de436c6f95.png">

## Refs
https://issues.folio.org/browse/UIU-2413