### PR TITLE
UIU-2414: Fix spacing of 'Suspended fees/fines' in Borrower section o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [6.2.0] (IN PROGRESS)
 
+* Fix spacing of "Suspended fees/fines" in Borrower section of Checkout page. Fixes UIU-2414.
 * Checking out to blocked patron doesn't offer override option. Refs UICHKOUT-725.
 * Add check for `ui-users.loans.view` permission in order to show link to loans in ui-users. Fixes UICHKOUT-727.
 * Add check for `ui-requests.view` permission in order to show link to requests in ui-requests. Fixes UICHKOUT-728.

--- a/src/components/UserDetail/Loans.js
+++ b/src/components/UserDetail/Loans.js
@@ -50,7 +50,7 @@ function Loans({
         </Link>
       );
     }
-                                     
+
     return <FormattedNumber value={openRequestsCount} />;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resources.openRequests, user.barcode]);
@@ -102,11 +102,17 @@ function Loans({
         >
           <KeyValue
             label={<FormattedMessage id="ui-checkout.openAccounts" />}
-            value={openAccountsCount}
-          />
-          <FormattedMessage
-            id="ui-checkout.suspendedAccounts"
-            values={{ suspendedAccountsCount: suspended }}
+            value={
+              <>
+                <div>
+                  {openAccountsCount}
+                </div>
+                <FormattedMessage
+                  id="ui-checkout.suspendedAccounts"
+                  values={{ suspendedAccountsCount: suspended }}
+                />
+              </>
+            }
           />
         </Col>
         <Col xs={4}>


### PR DESCRIPTION
## Purpose
We have requirement to get rid of blank line between the total fee/fine amount and the suspended fee/fine amount in the Borrower section of the Checkout page

## Approach
**KeyValue** react component has bottom margin. We have to put suspended fee/fine amount value to _value_ property of **KeyValue** component next to total fee/fine amount value to get rid of this bottom margin.

## Screenshots
Before:
<img width="1274" alt="before" src="https://user-images.githubusercontent.com/47976677/132840408-5256854a-b707-4d75-b9d2-2f5b97271a55.png">

After:
<img width="1267" alt="after2" src="https://user-images.githubusercontent.com/47976677/132840531-b35a3943-bc4b-40a3-86e0-d54340e7b2d4.png">


## Refs
https://issues.folio.org/browse/UIU-2414