### PR TITLE
UICHKOUT-743: Fix spacing of 'Suspended fees/fines' in Borrower secti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove `item-storage` `8.0` dependency that ui-checkout doesn't use directly. Refs UICHKOUT-718.
 * Add alternate `inventory` `11.0` dependency for optimistic locking. Refs UICHKOUT-718.
 * Always display fee/fine decimal places on Checkout page. Refs UICHKOUT-742.
+* Fix spacing of "Suspended fees/fines" in Borrower section of Checkout page. Refs UICHKOUT-743.
 
 ## [6.1.0](https://github.com/folio-org/ui-checkout/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.0.0...v6.1.0)

--- a/src/components/UserDetail/Loans.js
+++ b/src/components/UserDetail/Loans.js
@@ -108,11 +108,17 @@ function Loans({
         >
           <KeyValue
             label={<FormattedMessage id="ui-checkout.openAccounts" />}
-            value={openAccountsCount}
-          />
-          <FormattedMessage
-            id="ui-checkout.suspendedAccounts"
-            values={{ suspendedAccountsCount: suspended }}
+            value={
+              <>
+                <div>
+                  {openAccountsCount}
+                </div>
+                <FormattedMessage
+                  id="ui-checkout.suspendedAccounts"
+                  values={{ suspendedAccountsCount: suspended }}
+                />
+              </>
+            }
           />
         </Col>
         <Col xs={4}>


### PR DESCRIPTION
## Purpose
We have requirement to get rid of blank line between the total fee/fine amount and the suspended fee/fine amount in the Borrower section of the Checkout page

## Approach
**KeyValue** react component has bottom margin. We have to put suspended fee/fine amount value to _value_ property of **KeyValue** component next to total fee/fine amount value to get rid of this bottom margin.

## Screenshots
Before:
<img width="1274" alt="before" src="https://user-images.githubusercontent.com/47976677/132840408-5256854a-b707-4d75-b9d2-2f5b97271a55.png">

After:
<img width="1267" alt="after2" src="https://user-images.githubusercontent.com/47976677/132840531-b35a3943-bc4b-40a3-86e0-d54340e7b2d4.png">


## Refs
https://issues.folio.org/browse/UICHKOUT-743