### PR TITLE
UICHKOUT-756: Fix auto checkout of items with delivery requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * Fix an issue with the number of patron blocks when they were doubled. Refs UICHKOUT-750.
+* Fix auto checkout of items with delivery requests. Fixes UICHKOUT-756.
 
 ## [7.0.0](https://github.com/folio-org/ui-checkout/tree/v7.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v6.1.0...v7.0.0)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -240,6 +240,7 @@ class CheckOut extends React.Component {
     this.itemFormRef = React.createRef();
     this.timer = undefined;
     this.shouldSubmitAutomatically = hasIn(location, 'state.patronBarcode') && hasIn(location, 'state.itemBarcode');
+
     this.state = {
       submitting: false,
       loading: false,
@@ -363,7 +364,7 @@ class CheckOut extends React.Component {
   };
 
   submitForm = (domId) => {
-    const submitEvent = new Event('submit', { cancelable: true });
+    const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
     const form = document.querySelector(`#${domId}`);
 
     if (form) {


### PR DESCRIPTION
The auto submission worked fine in the past so I'm not sure `bubbles` is not required. I wonder if this has changed after we upgraded to react 17. 

https://issues.folio.org/browse/UICHKOUT-756