### PR TITLE
UICHKOUT-693: DueDatePicker is incorrectly instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Also support `circulation` `13.0`. Refs UICHKOUT-760.
 * Perform Wildcard Item Lookup Before Performing Checkout Transaction in Check Out App. Refs UICHKOUT-752.
 * Update Item List Modal Contents for Wildcard Item Lookup. Refs UICHKOUT-763.
+* DueDatePicker is incorrectly instantiated. Refs UICHKOUT-693.
 
 ## [7.1.0](https://github.com/folio-org/ui-checkout/tree/v7.1.0) (2021-11-10)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v7.0.0...v7.1.0)

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "final-form": "^4.19.1",
     "inactivity-timer": "^1.0.0",
     "lodash": "^4.17.4",
+    "moment-timezone": "^0.5.34",
     "prop-types": "^15.6.0",
     "react-audio-player": "^0.9.0",
     "react-final-form": "^6.4.0",

--- a/src/components/OverrideModal/OverrideModal.js
+++ b/src/components/OverrideModal/OverrideModal.js
@@ -1,7 +1,13 @@
-import React, { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import React, {
+  useState,
+} from 'react';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import PropTypes from 'prop-types';
 import { omit } from 'lodash';
+import moment from 'moment-timezone';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
@@ -18,13 +24,33 @@ import {
 import { DueDatePicker } from '@folio/stripes/smart-components';
 
 import { renderOrderedPatronBlocks } from '../../util';
+
 import {
-  DATE_PICKER_DEFAULTS,
   INVALID_DATE_MESSAGE,
   ITEM_NOT_LOANABLE,
   MAX_ITEM_BLOCK_LIMIT,
 } from '../../constants';
+
 import css from './OverrideModal.css';
+
+const getInitialValues = (timeZone) => {
+  const startOfTheDay = {
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0,
+  };
+  const date = moment()
+    .tz(timeZone)
+    .set(startOfTheDay)
+    .tz('UTC', true)
+    .format();
+
+  return {
+    date,
+    time: '23:59:00.000Z',
+  };
+};
 
 function OverrideModal(props) {
   const {
@@ -43,6 +69,7 @@ function OverrideModal(props) {
       barcode,
     },
   } = props;
+  const { timeZone } = useIntl();
   const [comment, setAdditionalInfo] = useState(patronBlockOverriddenComment);
   const [dueDate, setDatetime] = useState('');
 
@@ -159,21 +186,21 @@ function OverrideModal(props) {
         >
           <DueDatePicker
             required
-            initialValues={DATE_PICKER_DEFAULTS}
+            initialValues={getInitialValues(timeZone)}
             stripes={stripes}
             dateProps={{
               label: (
                 <FormattedMessage id="ui-checkout.cddd.date">
                   {label => `${label} *`}
                 </FormattedMessage>
-              )
+              ),
             }}
             timeProps={{
               label: (
                 <FormattedMessage id="ui-checkout.cddd.time">
                   {label => `${label} *`}
                 </FormattedMessage>
-              )
+              ),
             }}
             onChange={handleDateTimeChanged}
           />

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,11 +5,6 @@ export const errorTypes = {
   ITEM_CHECKED_OUT: 4,
 };
 
-export const DATE_PICKER_DEFAULTS = {
-  date: '',
-  time: '23:59:00.000Z',
-};
-
 export const MAX_RECORDS = 40;
 
 export const INVALID_DATE_MESSAGE = 'Invalid date';
@@ -26,7 +21,7 @@ export const OVERRIDABLE_ERROR_MESSAGES = [
 ];
 
 export const ERRORS_TO_HIDE = [
-  'Cannot check out item that already has an open loan'
+  'Cannot check out item that already has an open loan',
 ];
 
 export const statuses = {

--- a/test/bigtest/tests/override-patron-blocks-test.js
+++ b/test/bigtest/tests/override-patron-blocks-test.js
@@ -1,7 +1,7 @@
 import {
   beforeEach,
   describe,
-  it
+  it,
 } from '@bigtest/mocha';
 import { expect } from 'chai';
 import { Response } from 'miragejs';
@@ -25,14 +25,14 @@ describe('Override patron block', () => {
     name: 'Circ Desk 2',
     code: 'cd2',
     discoveryDisplayName: 'Circulation Desk -- Back Entrance',
-    pickupLocation: true
+    pickupLocation: true,
   };
 
   setupApplication({
     scenarios: ['manualPatronBlocks'],
     currentUser: {
       servicePoints: [servicePoint],
-      curServicePoint: servicePoint
+      curServicePoint: servicePoint,
     },
   });
 
@@ -47,7 +47,7 @@ describe('Override patron block', () => {
       item = this.server.create('item', { barcode });
       user = this.server.create('user', {
         barcode: userBarcode,
-        id: 1
+        id: 1,
       });
 
       await checkOut
@@ -107,9 +107,9 @@ describe('Override patron block', () => {
                   message: 'Item is not loanable',
                   parameters: [{
                     key: 'itemBarcode',
-                    value: '123'
-                  }]
-                }]
+                    value: '123',
+                  }],
+                }],
               });
             });
           });
@@ -126,8 +126,14 @@ describe('Override patron block', () => {
 
             it('should show override modal', () => {
               expect(checkOut.overrideModal.isPresent).to.be.true;
-              expect(checkOut.overrideModal.saveAndCloseButtonDisabled).to.be.true;
+            });
+
+            it('modal should have correct comment', () => {
               expect(checkOut.overrideModal.commentTextarea.value).to.equal('Reason');
+            });
+
+            it('"Save & close" button should be active', () => {
+              expect(checkOut.overrideModal.saveAndCloseButtonDisabled).to.be.false;
             });
 
             describe('fill override modal', () => {


### PR DESCRIPTION
## Purpose
DueDatePicker is incorrectly instantiated

## Approach
According to PO's сomment in ticket, we can preffil `date` field with current date.
To correctly show date at UI (according to time zone of tennant) and send it at back-end (in UTC), we need some magic, which happen in `getInitialValues` function.

## Refs
https://issues.folio.org/browse/UICHKOUT-693