### PR TITLE
UICHKOUT-708: Compile Translation Files into AST Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 * Add id for Pane component. Refs UICHKOUT-768.
 * Add pull request template. Refs UICHKOUT-771.
+* Compile Translation Files into AST Format. Refs UICHKOUT-708.
 
 ## [8.0.0](https://github.com/folio-org/ui-checkout/tree/v8.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v7.1.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lint": "eslint .",
     "test": "stripes test karma",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-checkout ./translations/checkout/compiled"
+    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-checkout ./translations/ui-checkout/compiled"
   },
   "devDependencies": {
     "@bigtest/convergence": "^1.1.1",


### PR DESCRIPTION
## Purpose
Compile Translation Files into AST Format.

## Approach
- Destination folder was renamed for consistency with other modules (Just for example https://github.com/folio-org/ui-users/blob/master/package.json#L843)
- We run locally command "yarn formatjs-compile" and we don't get any errors.

## Refs
https://issues.folio.org/browse/UICHKOUT-708

#### TODOS and Open Questions
Hello @zburke 
Could you please confirm that Jenkinsfile are deprecated and we don't need add 
`runScripts = [
   ['formatjs-compile': ''],
  ]`
to Jenkinsfile.?