### PR TITLE
UICHKOUT-767: remove request to `loan-policy-storage/loan-policies` end-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add id for Pane component. Refs UICHKOUT-768.
 * Add pull request template. Refs UICHKOUT-771.
 * Compile Translation Files into AST Format. Refs UICHKOUT-708.
+* Remove unnecessary request to `loan-policy-storage/loan-policies` end-point within checkout procedure. Refs UICHKOUT-767.
 
 ## [8.0.0](https://github.com/folio-org/ui-checkout/tree/v8.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v7.1.0...v8.0.0)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -60,14 +60,6 @@ function playSound(checkoutStatus, audioTheme, onFinishedPlaying) {
 
 class ScanItems extends React.Component {
   static manifest = Object.freeze({
-    loanPolicies: {
-      type: 'okapi',
-      records: 'loanPolicies',
-      path: 'loan-policy-storage/loan-policies',
-      accumulate: 'true',
-      fetch: false,
-      abortOnUnmount: true,
-    },
     checkout: {
       type: 'okapi',
       path: 'circulation/check-out-by-barcode',
@@ -364,7 +356,6 @@ class ScanItems extends React.Component {
   performAction(action, data) {
     this.setState({ loading: true, errors: [] });
     return action.POST(data)
-      .then(this.fetchLoanPolicy)
       .then(this.addScannedItem)
       .then(this.successfulCheckout)
       .then(this.updateAutomatedPatronBlocks)
@@ -400,21 +391,6 @@ class ScanItems extends React.Component {
     const scannedItems = [loan].concat(parentResources.scannedItems);
 
     return parentMutator.scannedItems.replace(scannedItems);
-  };
-
-  fetchLoanPolicy = async (loan) => {
-    const {
-      mutator: { loanPolicies },
-    } = this.props;
-
-    const query = `(id=="${loan.loanPolicyId}")`;
-
-    loanPolicies.reset();
-
-    const policies = await loanPolicies.GET({ params: { query } });
-    loan.loanPolicy = policies.find(p => p.id === loan.loanPolicyId);
-
-    return loan;
   };
 
   clearField(fieldName) {

--- a/test/bigtest/tests/override-loans-policy-test.js
+++ b/test/bigtest/tests/override-loans-policy-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import {
   beforeEach,
   describe,
-  it
+  it,
 } from '@bigtest/mocha';
 
 import setupApplication from '../helpers/setup-application';
@@ -62,15 +62,6 @@ describe('override loan policy', () => {
       beforeEach(async function () {
         item = this.server.create('item', { barcode: notLoanableItemBarcode });
 
-        this.server.get('/loan-policy-storage/loan-policies', {
-          loanPolicies: [{
-            id: notLoanablePolicyId,
-            name: notLoanablePolicyName,
-            loanable: false
-          }],
-          totalRecords: 1
-        });
-
         await checkOut
           .fillItemBarcode(notLoanableItemBarcode)
           .clickItemBtn();
@@ -106,12 +97,15 @@ describe('override loan policy', () => {
             userId: user.id,
             itemId: item.id,
             status: {
-              name: 'Open'
+              name: 'Open',
             },
             loanDate: '2017-03-05T18:32:31Z',
             action: 'checkedOutThroughOverride',
             loanPolicyId: notLoanablePolicyId,
-            item
+            item,
+            loanPolicy: {
+              name: notLoanablePolicyName,
+            },
           });
         });
 


### PR DESCRIPTION
## Purpose
Remove unnecessary request to `loan-policy-storage/loan-policies` end-point within checkout procedure.

## Approach
I've checked where and how data from this endpoint is using, and found that we need only policy name, which is already in responce from `circulation/check-out-by-barcode` end-point. Also we need `lostItemPolicyId` to create link to policy, but it's present at top level of  `circulation/check-out-by-barcode` responce too.
I checked workability of checkout procedure and case with not loanable item - works as expected.

## Refs
https://issues.folio.org/browse/UICHKOUT-767