### PR TITLE
UICHKOUT-773: fix focus issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change history for ui-checkout
 
 ## IN PROGRESS
+
 * Add id for Pane component. Refs UICHKOUT-768.
 * Add pull request template. Refs UICHKOUT-771.
 * Compile Translation Files into AST Format. Refs UICHKOUT-708.
+* Fix focus issue. Refs UICHKOUT-773.
 
 ## [8.0.0](https://github.com/folio-org/ui-checkout/tree/v8.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v7.1.0...v8.0.0)
+
 * Add preferred name to check out UI. Refs UICHKOUT-699.
 * Increase mocha version up to `9.0.0`. Refs UICHKOUT-762.
 * Also support `circulation` `12.0`. Refs UICHKOUT-758.

--- a/src/components/PatronForm/PatronForm.js
+++ b/src/components/PatronForm/PatronForm.js
@@ -188,6 +188,7 @@ class PatronForm extends React.Component {
               visibleColumns={['status', 'name', 'patronGroup', 'username', 'barcode']}
               columnMapping={this.columnMapping}
               disableRecordCreation={disableRecordCreation}
+              restoreFocus={false}
             />
           </Col>
         </Row>


### PR DESCRIPTION
## Purpose
According to [changes](https://github.com/folio-org/ui-plugin-find-user/pull/199) in `ui-plugin-find-user` to solve the problem with focus, we should additionaly pass `restoreFocus` into `Pluggable` component.

## Refs
https://issues.folio.org/browse/UICHKOUT-773