### PR TITLE
UICHKOUT-777: optional dependency @folio/circulation is out of date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove unnecessary request to `loan-policy-storage/loan-policies` end-point within checkout procedure. Refs UICHKOUT-767.
 * Fix focus issue. Refs UICHKOUT-773.
 * Refactor away from react-intl-safe-html. Refs UICHKOUT-721.
+* Optional dependency `@folio/circulation` is out of date. Refs UICHKOUT-777.
 
 ## [8.0.1](https://github.com/folio-org/ui-checkout/tree/v8.0.1) (2022-03-28)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.0.0...v8.0.1)

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/circulation": "^6.0.0",
+    "@folio/circulation": "^7.0.0",
     "@folio/plugin-create-inventory-records": "^3.0.0",
     "@folio/plugin-find-user": "^6.0.0"
   }


### PR DESCRIPTION
## Purpose
Optional dependency `@folio/circulation` is out of date

## Refs
https://issues.folio.org/browse/UICHKOUT-777
