### PR TITLE
Enable error message when entering an item barcode without a patron barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix focus issue. Refs UICHKOUT-773.
 * Refactor away from react-intl-safe-html. Refs UICHKOUT-721.
 * Optional dependency `@folio/circulation` is out of date. Refs UICHKOUT-777.
+* Enable error message when entering an item barcode without a patron barcode. Refs UICHKOUT-770.
 
 ## [8.0.1](https://github.com/folio-org/ui-checkout/tree/v8.0.1) (2022-03-28)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.0.0...v8.0.1)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -183,7 +183,7 @@ class ScanItems extends React.Component {
 
   // https://github.com/final-form/react-final-form/blob/master/docs/faq.md#how-can-i-trigger-a-submit-from-outside-my-form
   triggerPatronFormSubmit = () => {
-    const submitEvent = new Event('submit', { cancelable: true });
+    const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
     const form = document.querySelector('#patron-form');
     form.dispatchEvent(submitEvent);
   };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UICHKOUT-771: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
Enable error message when entering an item barcode without a patron barcode

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UICHKOUT-771
-->
[UICHKOUT-770](https://issues.folio.org/browse/UICHKOUT-770)

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->
![image](https://user-images.githubusercontent.com/42437614/163939583-43686a81-c9a8-4e73-997b-d82f6725db97.png)

