### PR TITLE
UICHKOUT-782 back node to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=14.0.0"
   },
   "main": "src/index.js",
   "stripes": {


### PR DESCRIPTION
GA builds can require NodeJS v16, but ATM the platform is still built on
Jenkins where v14 is the standard.

Refs [UICHKOUT-782](https://issues.folio.org/browse/UICHKOUT-782)