### PR TITLE
UICHKOUT-792 when formatting names, handle falsy values similarly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* Handle empty values like other falsy values when formatting names. Refs UICHKOUT-792.
+
 ## [8.1.0](https://github.com/folio-org/ui-checkout/tree/v8.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.0.1...v8.1.0)
 
@@ -25,7 +27,7 @@
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.0.0...v8.0.1)
 
 * Patron block count increases erroneously when override entered at Check-out. Refs UICHKOUT-774.
-* Extend ui-checkout.circulation sub permissions. Refs UICHKOUT-775. 
+* Extend ui-checkout.circulation sub permissions. Refs UICHKOUT-775.
 
 ## [8.0.0](https://github.com/folio-org/ui-checkout/tree/v8.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v7.1.0...v8.0.0)

--- a/src/util.js
+++ b/src/util.js
@@ -7,7 +7,7 @@ import { Col, Row } from '@folio/stripes/components';
 import { defaultPatronIdentifier, statuses } from './constants';
 
 export function getFullName(user) {
-  return `${user?.personal?.lastName ?? ''}, ${user?.personal?.preferredFirstName ?? user?.personal?.firstName ?? ''} ${user?.personal?.middleName ?? ''}`;
+  return `${user?.personal?.lastName || ''}, ${user?.personal?.preferredFirstName || user?.personal?.firstName || ''} ${user?.personal?.middleName || ''}`;
 }
 
 export function getCheckoutSettings(checkoutSettings) {

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -52,5 +52,16 @@ describe('util', () => {
         },
       })).toEqual('LastName, PreferredFirstName MiddleName');
     });
+
+    it('should handle empty preferred first name', () => {
+      const preferredFirstName = '';
+      expect(getFullName({
+        personal: {
+          ...personal,
+          middleName,
+          preferredFirstName,
+        },
+      })).toEqual('LastName, FirstName MiddleName');
+    });
   });
 });


### PR DESCRIPTION
When formatting a name, handle empty-string values the same way as other
falsy values. Previously, the formatter only checked if values were null
or undefined; empty-string values were ignored. This led objects like
```
{
  firstName: "Andrea",
  preferredFirstName: "",
  lastName: "Andromeda"
}
```
to be formatted as "Andromeda" instead of "Andromeda, Andrea" because
`preferredFirstName` was non-null. Now, undefined, null, and empty
string will all be treated as falsy.

Refs [UICHKOUT-792](https://issues.folio.org/browse/UICHKOUT-792)