### PR TITLE
UICHKOUT-800: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Handle empty values like other falsy values when formatting names. Refs UICHKOUT-792.
+* Also support `inventory` `12.0`. Refs UICHKOUT-800.
 
 ## [8.1.0](https://github.com/folio-org/ui-checkout/tree/v8.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.0.1...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "configuration": "2.0",
       "loan-policy-storage": "1.0 2.0",
       "users": "15.0",
-      "inventory": "10.0 11.0",
+      "inventory": "10.0 11.0 12.0",
       "automated-patron-blocks": "0.1"
     },
     "permissionSets": [


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-checkout doesn't need any code change because it doesn't use these two DELETE APIs.