### PR TITLE
UICHKOUT-818: bump stripes to 8.0.0 for Orchid/2023-R1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Visual indicator in checkout due date column for shortened loan period - part1. Refs UICHKOUT-810
 * Fix Due date in Check out: Last number goes to the next line. Refs UICHKOUT-811.
 * Checkout table usability improvements. Ref UICHKOUT-805.
+* Bump major versions of several @folio/stripes-* packages. Refs UICHKOUT-818.
 
 ## [8.2.0](https://github.com/folio-org/ui-checkout/tree/v8.2.0) (2022-10-20)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.1.0...v8.2.0)

--- a/package.json
+++ b/package.json
@@ -110,10 +110,10 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^6.0.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.0.0",
-    "@folio/stripes-components": "^10.0.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "@formatjs/cli": "^4.2.20",
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.9",
@@ -151,7 +151,7 @@
     "react-final-form": "^6.4.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "moment": "^2.29.0",
     "react": "^17.0.2",
     "react-intl": "^5.8.0",


### PR DESCRIPTION
## Purpose
Bump major versions of several @folio/stripes-* packages.

## Refs
[UICHKOUT-818](https://issues.folio.org/browse/UICHKOUT-818)