### PR TITLE
UICHKOUT-841 Drop react-redux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-checkout
 
-## (9.0.0) in progress
+## in progress
 
 * Visual indicator in checkout due date column for shortened loan period - part1. Refs UICHKOUT-806
 * Visual indicator in checkout due date column for shortened loan period - part1. Refs UICHKOUT-809
@@ -8,7 +8,7 @@
 * Fix Due date in Check out: Last number goes to the next line. Refs UICHKOUT-811.
 * Checkout table usability improvements. Ref UICHKOUT-805.
 * Bump major versions of several @folio/stripes-* packages. Refs UICHKOUT-818.
-* Upgrade `react-redux` to `v8`. Upgrade `stripes` to `v8`. Refs UICHKOUT-841.
+* Remove unneeded `react-redux` dependency. Refs UICHKOUT-841.
 
 ## [8.2.0](https://github.com/folio-org/ui-checkout/tree/v8.2.0) (2022-10-20)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.1.0...v8.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-checkout
 
-## in progress
+## (9.0.0) in progress
 
 * Visual indicator in checkout due date column for shortened loan period - part1. Refs UICHKOUT-806
 * Visual indicator in checkout due date column for shortened loan period - part1. Refs UICHKOUT-809
@@ -8,6 +8,7 @@
 * Fix Due date in Check out: Last number goes to the next line. Refs UICHKOUT-811.
 * Checkout table usability improvements. Ref UICHKOUT-805.
 * Bump major versions of several @folio/stripes-* packages. Refs UICHKOUT-818.
+* Upgrade `react-redux` to `v8`. Upgrade `stripes` to `v8`. Refs UICHKOUT-841.
 
 ## [8.2.0](https://github.com/folio-org/ui-checkout/tree/v8.2.0) (2022-10-20)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.1.0...v8.2.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkout",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "Item Check-out",
   "repository": "folio-org/ui-checkout",
   "publishConfig": {
@@ -135,7 +135,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
@@ -155,6 +155,7 @@
     "moment": "^2.29.0",
     "react": "^17.0.2",
     "react-intl": "^5.8.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkout",
-  "version": "9.0.0",
+  "version": "8.2.0",
   "description": "Item Check-out",
   "repository": "folio-org/ui-checkout",
   "publishConfig": {
@@ -135,7 +135,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
@@ -155,7 +154,6 @@
     "moment": "^2.29.0",
     "react": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UICHKOUT-841.
- Remove unneeded `react-redux` dependency.