### PR TITLE
UICHKOUT-846: Awaiting Pickup Modal in Checkout not showing current count of items awaiting pickup if more than 10 items are awaiting pickup at the service point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * Remove unneeded `react-redux` dependency. Refs UICHKOUT-841.
 * Support `inventory` `13.0` interface version. Refs UICHKOUT-814.
 * Add screen reader accessibility to checkout flag. Refs UICHKOUT-842
-* UI tests replacement with RTL/Jest for NotificationModal. Refs UIREQ-829.
+* UI tests replacement with RTL/Jest for `NotificationModal`. Refs UICHKOUT-829.
+* `PickupModal`: Show count of items awaiting pickup based on `totalRecords` API response field. Refs UICHKOUT-846.
 
 ## [8.2.0](https://github.com/folio-org/ui-checkout/tree/v8.2.0) (2022-10-20)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.1.0...v8.2.0)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -106,7 +106,6 @@ class CheckOut extends React.Component {
     },
     requests: {
       type: 'okapi',
-      records: 'requests',
       accumulate: 'true',
       path: 'circulation/requests',
       fetch: false,
@@ -547,8 +546,8 @@ class CheckOut extends React.Component {
     const servicePointId = get(stripes, ['user', 'user', 'curServicePoint', 'id'], '');
     const query = buildRequestQuery(patron.id, servicePointId);
     mutator.requests.reset();
-    const requests = await mutator.requests.GET({ params: { query } });
-    this.setState({ requestsCount: requests.length });
+    const { totalRecords } = await mutator.requests.GET({ params: { query } });
+    this.setState({ requestsCount: totalRecords });
   }
 
   onCloseBlockedModal = () => this.setState({ blocked: false });


### PR DESCRIPTION
## Purpose
To show relevant data as previous implementation doesn't reflect the real data in all cases

## Approach
`circulation/requests` API returns an array of requests and a field `totalRecords`. Before, the requests amount was calculated via the `requests` array length. But, if there are more than 10 requests, the array has the length of no more than 10 for some particular reason, while the `totalRecords` field has the right amount of total requests. Therefore, I've decided to use `totalRecords` field for this data value.

## Refs
https://issues.folio.org/browse/UICHKOUT-846

#### TODOS and Open Questions
As I have no thorough understanding of the functionality yet this might be not the right approach. Please let me know if it is so.