### PR TITLE
UICHKOUT-848: Use camel case notation for all data-testid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * UI tests replacement with RTL/Jest for `ErrorModal.js`. Refs UICHKOUT-826
 * UI tests replacement with RTL/Jest for src/components/ScanFooter/ScanFooter.js. Refs UICHKOUT-834.
 * UI tests replacement with RTL/Jest for src/components/ScanTotal/ScanTotal.js. Refs UICHKOUT-835.
+* Use camel case notation for all data-testid. Refs UICHKOUT-848.
 
 ## [9.0.0](https://github.com/folio-org/ui-checkout/tree/v9.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.2.0...v9.0.0)

--- a/src/components/NotificationModal/NotificationModal.js
+++ b/src/components/NotificationModal/NotificationModal.js
@@ -15,7 +15,7 @@ const NotificationModal = ({
   const footer = (
     <ModalFooter>
       <Button
-        data-testid="footer-close-button"
+        data-testid="footerCloseButton"
         onClick={onClose}
       >
         <FormattedMessage id="ui-checkout.close" />
@@ -28,7 +28,7 @@ const NotificationModal = ({
       size="small"
       footer={footer}
       dismissible
-      data-testid="notification-modal"
+      data-testid="notificationModal"
       onClose={onClose}
       {...rest}
     >

--- a/src/components/NotificationModal/NotificationModal.test.js
+++ b/src/components/NotificationModal/NotificationModal.test.js
@@ -13,8 +13,8 @@ import NotificationModal from '.';
 describe('NotificationModal', () => {
   const closeModal = jest.fn();
   const testIds = {
-    notificationModal: 'notification-modal',
-    footerCloseButton: 'footer-close-button',
+    notificationModal: 'notificationModal',
+    footerCloseButton: 'footerCloseButton',
   };
   const labelIds = {
     footerMessageId: 'ui-checkout.close',

--- a/src/util.js
+++ b/src/util.js
@@ -83,7 +83,7 @@ export function renderOrderedPatronBlocks(patronBlocks) {
         <Col xs>
           <b
             data-test-block-message
-            data-testid="block-message"
+            data-testid="blockMessage"
           >
             {content}
           </b>

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -20,6 +20,10 @@ import {
   OPEN_REQUEST_STATUSES,
 } from './constants';
 
+const testIds = {
+  blockMessage: 'blockMessage',
+};
+
 describe('util', () => {
   const lastName = 'LastName';
   const firstName = 'FirstName';
@@ -64,6 +68,7 @@ describe('util', () => {
 
     it('should return last name, preferred first name and middle name', () => {
       const preferredFirstName = 'PreferredFirstName';
+
       expect(getFullName({
         personal: {
           ...personal,
@@ -75,6 +80,7 @@ describe('util', () => {
 
     it('should handle empty preferred first name', () => {
       const preferredFirstName = '';
+
       expect(getFullName({
         personal: {
           ...personal,
@@ -162,21 +168,25 @@ describe('util', () => {
 
   describe('renderOrderedPatronBlocks', () => {
     it('should render patron blocks with desc field content', () => {
-      render(renderOrderedPatronBlocks([{ id: 0, desc: 'Description' }]));
+      const description = 'Description';
 
-      expect(screen.getByText('Description')).toBeInTheDocument();
+      render(renderOrderedPatronBlocks([{ id: 0, desc: description }]));
+
+      expect(screen.getByText(description)).toBeInTheDocument();
     });
 
     it('should render patron blocks with message field content as fallback', () => {
-      render(renderOrderedPatronBlocks([{ id: 0, message: 'Message' }]));
+      const message = 'Message';
 
-      expect(screen.getByText('Message')).toBeInTheDocument();
+      render(renderOrderedPatronBlocks([{ id: 0, message }]));
+
+      expect(screen.getByText(message)).toBeInTheDocument();
     });
 
     it('should render patron blocks empty if no fallbacks are present', () => {
       render(renderOrderedPatronBlocks([{ id: 0 }]));
 
-      expect(screen.getByTestId('block-message')).toBeEmptyDOMElement();
+      expect(screen.getByTestId(testIds.blockMessage)).toBeEmptyDOMElement();
     });
   });
 });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -56,7 +56,7 @@ jest.mock('@folio/stripes/components', () => ({
   }) => (
     <div
       id={id}
-      data-testid={testId ?? 'modal-window'}
+      data-testid={testId ?? 'modalWindow'}
     >
       <p>{label}</p>
       {children}


### PR DESCRIPTION
## Purpose
- Use camel case notation for all data-testid
- Remove magic strings for testIds and labelIds

## Refs
https://issues.folio.org/browse/UICHKOUT-848