### PR TITLE
UICHKOUT-834: UI tests replacement with RTL/Jest for src/components/ScanFooter/ScanFooter.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * UI tests replacement with RTL/Jest for src/components/PatronBlock/PatronBlockModal.js. Refs UICHKOUT-832.
 * UI tests replacement with RTL/Jest for `ErrorModal.js`. Refs UICHKOUT-826
+* UI tests replacement with RTL/Jest for src/components/ScanFooter/ScanFooter.js. Refs UICHKOUT-834.
 
 ## [9.0.0](https://github.com/folio-org/ui-checkout/tree/v9.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.2.0...v9.0.0)

--- a/src/components/ScanFooter/ScanFooter.js
+++ b/src/components/ScanFooter/ScanFooter.js
@@ -9,7 +9,10 @@ import ScanTotal from '../ScanTotal';
 import css from './ScanFooter.css';
 
 const ScanFooter = props => (
-  <div className={css.root}>
+  <div
+    data-testid="scanFooter"
+    className={css.root}
+  >
     <Row>
       <Col
         xsOffset={8}

--- a/src/components/ScanFooter/ScanFooter.test.js
+++ b/src/components/ScanFooter/ScanFooter.test.js
@@ -1,0 +1,44 @@
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import ScanFooter from './ScanFooter';
+import ScanTotal from '../ScanTotal';
+
+jest.mock('../ScanTotal', () => jest.fn(() => null));
+
+const testIds = {
+  scanFooter: 'scanFooter',
+};
+
+describe('ScanFooter', () => {
+  const props = {
+    test: 'test',
+  };
+
+  beforeEach(() => {
+    render(
+      <ScanFooter
+        {...props}
+      />
+    );
+  });
+
+  it('should render "ScanFooter" component', () => {
+    const scanFooter = screen.getByTestId(testIds.scanFooter);
+
+    expect(scanFooter).toBeInTheDocument();
+  });
+
+  it('should trigger "ScanTotal" with correct props', () => {
+    const expectedProps = {
+      ...props,
+      buttonId: 'clickable-done-footer',
+    };
+
+    expect(ScanTotal).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});
+  });
+});


### PR DESCRIPTION
## Purpose
UI tests replacement with RTL/Jest for src/components/ScanFooter/ScanFooter.js

## Refs
[UICHKOUT-834](https://issues.folio.org/browse/UICHKOUT-834)

## Screenshot
![image](https://user-images.githubusercontent.com/42437614/221657968-d9091afa-f692-4503-aadd-50b5ba790506.png)
