### PR TITLE
UICHKOUT-849: Update @folio/circulation to 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * UI tests replacement with RTL/Jest for `PatronBlock.js`. Refs UICHKOUT-831
 * UI tests replacement with RTL/Jest for `SelectItemModal.js`. Refs UICHKOUT-836.
 * UI tests replacement with RTL/Jest for src/components/UserDetail/Loans.js. Refs UICHKOUT-837
+* Update `@folio/circulation` to `8.0.1`. Refs UICHKOUT-849.
 
 ## [9.0.0](https://github.com/folio-org/ui-checkout/tree/v9.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v8.2.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/circulation": "^7.0.0",
+    "@folio/circulation": "^8.0.1",
     "@folio/plugin-create-inventory-records": "^3.0.0",
     "@folio/plugin-find-user": "^6.0.0"
   }


### PR DESCRIPTION
## Purpose
Update @folio/circulation to 8.0.1

## Refs
https://issues.folio.org/browse/UICHKOUT-849

## Notes
This pull request depends on https://github.com/folio-org/ui-circulation/pull/1009
After merge https://github.com/folio-org/ui-circulation/pull/1009 we will ralease ui-circulation with version 8.0.1