### PR TITLE
UICHKOUT-853: Requests search is using CQL with = for service point filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * UI tests replacement with RTL/Jest for src/components/UserDetail/Loans.js. Refs UICHKOUT-837
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `CheckOut.js`. Refs UICHKOUT-850.
 * Reassign limit variable from hardcoded value to MAX_RECORDS constant for `UserDetail.js`. Refs UICHKOUT-851.
+* Use == instead of = for CQL service point filtering. Refs UICHKOUT-853.
 
 ## [9.0.1](https://github.com/folio-org/ui-checkout/tree/v9.0.1) (2023-03-08)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v9.0.0...v9.0.1)

--- a/src/util.js
+++ b/src/util.js
@@ -46,7 +46,7 @@ export function buildIdentifierQuery(patron, idents) {
 }
 
 export function buildRequestQuery(requesterId, servicePointId) {
-  const servicePointClause = servicePointId ? `pickupServicePointId=${servicePointId} and ` : '';
+  const servicePointClause = servicePointId ? `pickupServicePointId==${servicePointId} and ` : '';
   return `(requesterId==${requesterId} and ${servicePointClause}status=="${OPEN_REQUEST_STATUSES.OPEN_AWAITING_PICKUP}")`;
 }
 

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -132,7 +132,7 @@ describe('util', () => {
 
     it('should convert requesterId and servicePointId to a CQL query', () => {
       expect(buildRequestQuery(mockId, mockId))
-        .toEqual(`(requesterId==${mockId} and pickupServicePointId=${mockId} and status=="${OPEN_AWAITING_PICKUP}")`);
+        .toEqual(`(requesterId==${mockId} and pickupServicePointId==${mockId} and status=="${OPEN_AWAITING_PICKUP}")`);
     });
   });
 


### PR DESCRIPTION
## Purpose
Use == instead of = for CQL service point filtering.

## Refs
[UICHKOUT-853](https://issues.folio.org/browse/UICHKOUT-853)