### PR TITLE
UICHKOUT-861: Upgrade babel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * UI tests replacement with RTL/Jest for src/components/PatronForm/PatronForm.js. Refs UICHKOUT-833.
 * Update check out ellipses UX for consistency. Refs UICHKOUT-856.
 * UI tests replacement with RTL/Jest for src/components/ItemForm/ItemForm.js. Refs UICHKOUT-827.
+* Upgrade babel config. Refs UICHKOUT-861.
 
 ## [9.0.1](https://github.com/folio-org/ui-checkout/tree/v9.0.1) (2023-03-08)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v9.0.0...v9.0.1)

--- a/package.json
+++ b/package.json
@@ -103,9 +103,6 @@
   "devDependencies": {
     "@babel/core": "^7.17.12",
     "@babel/eslint-parser": "^7.17.0",
-    "@babel/plugin-proposal-class-properties": "^7.17.12",
-    "@babel/plugin-proposal-decorators": "^7.18.2",
-    "@babel/plugin-transform-runtime": "^7.18.5",
     "@bigtest/interactor": "^0.9.1",
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.2",

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,12 +1,5 @@
+const { babelOptions } = require('@folio/stripes-cli');
+
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    ['@babel/preset-react', { 'runtime': 'automatic' }],
-  ],
-  plugins: [
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-transform-private-methods', { loose: true }],
-    '@babel/plugin-transform-runtime',
-  ],
+  ...babelOptions,
 };


### PR DESCRIPTION
## Purpose
Upgrade babel config

## Approach
Pulling the babel config directly from stripes-webpack via stripes-cli, in order to guarantee the babel plugins, versions, and config are all aligned.

## Refs
https://issues.folio.org/browse/UICHKOUT-861