### PR TITLE
UICHKOUT-887: Use Save & close button label stripes-component translation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * UI tests replacement with RTL/Jest for AddInfoDialog.js. Refs UICHKOUT-878.
 * Hide 'Item details' in Action menu when item is virtual. Refs. UICHKOUT-871.
 * Hide Patron and Staff Info in Action menu when DCB patron. Refs. UICHKOUT-872.
+* Use Save & close button label stripes-component translation key.Refs UICHKOUT-887.
 
 ## [10.0.1](https://github.com/folio-org/ui-checkout/tree/v10.0.1) (2023-10-23)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v10.0.0...v10.0.1)

--- a/src/components/OverrideModal/OverrideModal.js
+++ b/src/components/OverrideModal/OverrideModal.js
@@ -142,7 +142,7 @@ function OverrideModal(props) {
         disabled={!canBeSubmitted}
         onClick={onSubmit}
       >
-        <FormattedMessage id="ui-checkout.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
       <Button
         data-testid="cancelButton"

--- a/src/components/OverrideModal/OverrideModal.test.js
+++ b/src/components/OverrideModal/OverrideModal.test.js
@@ -64,7 +64,7 @@ const labelIds = {
   overrideItemBlock: 'ui-checkout.overrideItemBlock',
   additionalReasons: 'ui-checkout.additionalReasons',
   itemWillBeCheckedOut: 'ui-checkout.messages.itemWillBeCheckedOut',
-  saveAndClose: 'ui-checkout.saveAndClose',
+  saveAndClose: /saveAndClose/,
   cancel: 'ui-checkout.cancel',
   comment: 'ui-checkout.comment',
   date: 'ui-checkout.cddd.date',

--- a/src/components/ViewItem/AddInfoDialog.js
+++ b/src/components/ViewItem/AddInfoDialog.js
@@ -41,7 +41,7 @@ function AddInfoDialog({ loan, infoType, addPatronOrStaffInfo, onClose }) {
           disabled={!textEntered}
           onClick={submitInfo}
         >
-          <FormattedMessage id="ui-checkout.saveAndClose" />
+          <FormattedMessage id="stripes-components.saveAndClose" />
         </Button>
       </div>
     </ModalFooter>

--- a/src/components/ViewItem/AddInfoDialog.test.js
+++ b/src/components/ViewItem/AddInfoDialog.test.js
@@ -10,7 +10,7 @@ import AddInfoDialog from './AddInfoDialog';
 const infoType = 'infoType';
 const labelIds = {
   cancelButton: 'ui-checkout.cancel',
-  saveAndCloseButton: 'ui-checkout.saveAndClose',
+  saveAndCloseButton: /saveAndClose/,
   modalLabel: `ui-checkout.checkout.addInfo.${infoType}.header`,
   modalBody: `ui-checkout.checkout.addInfo.${infoType}.body`,
 };

--- a/translations/ui-checkout/en.json
+++ b/translations/ui-checkout/en.json
@@ -111,7 +111,6 @@
   "cddd.time": "Time",
   "comment": "Comment",
   "override": "Override",
-  "saveAndClose": "Save & close",
   "overrideLoanPolicy": "Override loan policy",
   "overrideItemBlock": "Override item block",
   "overridePatronBlock": "Override patron block",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UICHKOUT-887
We removed local translation key and replace it with global one `stripes-components.saveAndClose`