### PR TITLE
UICHKOUT-903: When checking in/out items, an added space will cause check in and check out notes to not pop up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 10.2.0 IN PROGRESS
 
+* Trim spaces around barcode to send correct information to the server side. Refs UICHKOUT-903.
 
 ## [10.1.0](https://github.com/folio-org/ui-checkout/tree/v10.1.0) (2024-03-22)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v10.0.1...v10.1.0)

--- a/src/ScanItems.js
+++ b/src/ScanItems.js
@@ -245,7 +245,7 @@ class ScanItems extends React.Component {
       patronBlocks,
     } = this.props;
 
-    const barcode = get(data, 'item.barcode');
+    const barcode = get(data, 'item.barcode', '').trim();
     const errors = this.validate(barcode);
 
     if (!isEmpty(errors)) {
@@ -292,7 +292,7 @@ class ScanItems extends React.Component {
     const { stripes, patron, proxy } = this.props;
     const servicePointId = get(stripes, 'user.user.curServicePoint.id', '');
     const data = {
-      itemBarcode: barcode.trim(),
+      itemBarcode: barcode,
       userBarcode: patron.barcode,
       servicePointId,
     };


### PR DESCRIPTION
## Purpose
Trim spaces around barcode to send correct information to the server side

## Refs
[UICHKOUT-903](https://folio-org.atlassian.net/browse/UICHKOUT-903)