### PR TITLE
UICHKOUT-886: Break long words in headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Hide 'Item details' in Action menu when item is virtual. Refs. UICHKOUT-871.
 * Hide Patron and Staff Info in Action menu when DCB patron. Refs. UICHKOUT-872.
 * Use Save & close button label stripes-component translation key.Refs UICHKOUT-887.
+* Fix words breaking on checkout table. Refs UICHKOUT-886.
 
 ## [10.0.1](https://github.com/folio-org/ui-checkout/tree/v10.0.1) (2023-10-23)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v10.0.0...v10.0.1)

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -58,13 +58,13 @@ export const visibleColumns = [
 ];
 
 export const columnWidths = {
-  [COLUMNS_NAME.BARCODE]: '10%',
-  [COLUMNS_NAME.TITLE]: '27%',
-  [COLUMNS_NAME.LOAN_POLICY]: '20%',
-  [COLUMNS_NAME.DUE_DATE]: '13%',
-  [COLUMNS_NAME.TIME]: '10%',
-  [COLUMNS_NAME.ACTION]: '10%',
-  [COLUMNS_NAME.NO]: '8%'
+  [COLUMNS_NAME.NO]: { max: 80 },
+  [COLUMNS_NAME.BARCODE]: { max: 150 },
+  [COLUMNS_NAME.TITLE]: { max: 250 },
+  [COLUMNS_NAME.LOAN_POLICY]: { max: 180 },
+  [COLUMNS_NAME.DUE_DATE]: { max: 100 },
+  [COLUMNS_NAME.TIME]: { max: 80 },
+  [COLUMNS_NAME.ACTION]: { max: 80 },
 };
 
 class ViewItem extends React.Component {


### PR DESCRIPTION
## Purpose
Fix headings words breaking on checkout table.

## Approach
I use fixed width for each column instead of percentages (approach approved by PO). 

## Refs
[UICHKOUT-886](https://folio-org.atlassian.net/browse/UICHKOUT-886)