### PR TITLE
UICHKOUT-925: Update ui-plugin-create-inventory-records to version 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update notes permission. Refs - UICHKOUT-920.
 * Also support okapiInterfaces `inventory` `14.0`. Refs UICHKOUT-922.
 * Review and cleanup Module Descriptor. Refs UICHKOUT-919.
+* Update `ui-plugin-create-inventory-records` to version `5.0.0`. Refs UICHKOUT-925.
 
 ## [10.1.0](https://github.com/folio-org/ui-checkout/tree/v10.1.0) (2024-03-22)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v10.0.1...v10.1.0)

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   },
   "optionalDependencies": {
     "@folio/circulation": "^9.0.0",
-    "@folio/plugin-create-inventory-records": "^4.0.0",
+    "@folio/plugin-create-inventory-records": "^5.0.0",
     "@folio/plugin-find-user": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Purpose
Update ui-plugin-create-inventory-records to version 5.0.0

# Refs
https://issues.folio.org/browse/UICHKOUT-925