### PR TITLE
UICHKOUT-927 - Update permission checks of ui-users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-checkout
 
+## [11.0.1] In progress
+* Update permission checks of ui-users
+
 ## [11.0.0](https://github.com/folio-org/ui-checkout/tree/v11.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v10.1.0...v11.0.0)
 * Remove bigtests from github actions. Refs UICHKOUT-908.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for ui-checkout
 
 ## [11.0.1] In progress
-* Update permission checks of ui-users
+* Update permission checks of ui-users. Refs UICHKOUT-927.
 
 ## [11.0.0](https://github.com/folio-org/ui-checkout/tree/v11.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v10.1.0...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
     "@babel/eslint-parser": "^7.17.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.0.0",
+    "@folio/stripes": "^9.2.5",
     "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-components": "^12.0.0",
-    "@folio/stripes-core": "^10.0.0",
+    "@folio/stripes-core": "^10.2.3",
     "@folio/stripes-testing": "^4.4.0",
     "@formatjs/cli": "^6.1.3",
     "core-js": "^3.6.4",
@@ -135,7 +135,7 @@
     "react-final-form": "^6.4.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.0.0",
+    "@folio/stripes": "^9.2.5",
     "moment": "^2.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -106,7 +106,7 @@ function ErrorModal({
     }
   });
 
-  const canBeOverridden = stripes.hasPerm('ui-users.overrideItemBlock')
+  const canBeOverridden = stripes.hasAnyPerm('ui-users.overrideItemBlock,ui-users.override-item-block.execute')
     && containsOverrideErrorMessage;
 
   return (

--- a/src/components/ErrorModal/ErrorModal.test.js
+++ b/src/components/ErrorModal/ErrorModal.test.js
@@ -22,7 +22,7 @@ import ErrorModal from './ErrorModal';
 describe('ErrorModal', () => {
   const onClose = jest.fn();
   const openOverrideModal = jest.fn();
-  const hasAnyPerm = (arg) => arg === 'ui-users.overrideItemBlock' || arg === 'ui-users.override-item-block.execute';
+  const hasAnyPerm = (arg) => arg === 'ui-users.overrideItemBlock,ui-users.override-item-block.execute';
   const testIds = {
     errorModal: 'errorModal',
     errorItem: 'errorItem',
@@ -108,7 +108,7 @@ describe('ErrorModal', () => {
         }],
         stripes: {
           ...buildStripes(),
-          hasPerm,
+          hasAnyPerm,
         }
       });
 
@@ -123,7 +123,7 @@ describe('ErrorModal', () => {
         }],
         stripes: {
           ...buildStripes(),
-          hasPerm,
+          hasAnyPerm,
         },
         openOverrideModal,
       });

--- a/src/components/ErrorModal/ErrorModal.test.js
+++ b/src/components/ErrorModal/ErrorModal.test.js
@@ -22,7 +22,7 @@ import ErrorModal from './ErrorModal';
 describe('ErrorModal', () => {
   const onClose = jest.fn();
   const openOverrideModal = jest.fn();
-  const hasPerm = (arg) => arg === 'ui-users.overrideItemBlock' || arg === 'ui-users.override-item-block.execute';
+  const hasAnyPerm = (arg) => arg === 'ui-users.overrideItemBlock' || arg === 'ui-users.override-item-block.execute';
   const testIds = {
     errorModal: 'errorModal',
     errorItem: 'errorItem',
@@ -82,7 +82,7 @@ describe('ErrorModal', () => {
         }],
         stripes: {
           ...buildStripes(),
-          hasPerm,
+          hasAnyPerm,
         }
       });
 

--- a/src/components/ErrorModal/ErrorModal.test.js
+++ b/src/components/ErrorModal/ErrorModal.test.js
@@ -22,7 +22,7 @@ import ErrorModal from './ErrorModal';
 describe('ErrorModal', () => {
   const onClose = jest.fn();
   const openOverrideModal = jest.fn();
-  const hasPerm = (arg) => arg === 'ui-users.overrideItemBlock';
+  const hasPerm = (arg) => arg === 'ui-users.overrideItemBlock' || arg === 'ui-users.override-item-block.execute';
   const testIds = {
     errorModal: 'errorModal',
     errorItem: 'errorItem',

--- a/src/components/PatronBlock/PatronBlockModal.js
+++ b/src/components/PatronBlock/PatronBlockModal.js
@@ -7,7 +7,7 @@ import {
   Modal,
   Row
 } from '@folio/stripes/components';
-import { IfPermission } from '@folio/stripes/core';
+import { IfAnyPermission } from '@folio/stripes/core';
 
 import { renderOrderedPatronBlocks } from '../../util';
 
@@ -42,7 +42,7 @@ const PatronBlockModal = ({
         <Col xs={6}>
           <Row end="xs">
             <Col>
-              <IfPermission perm="ui-users.overridePatronBlock">
+              <IfAnyPermission perm="ui-users.overridePatronBlock,ui-users.override-patron-block.execute">
                 <Button
                   data-test-override-patron-block-button
                   data-testid="overrideButton"
@@ -50,7 +50,7 @@ const PatronBlockModal = ({
                 >
                   <FormattedMessage id="ui-checkout.override" />
                 </Button>
-              </IfPermission>
+              </IfAnyPermission>
               <Button
                 data-test-close-patron-block-modal
                 data-testid="closeButton"

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -370,7 +370,7 @@ class ViewItem extends React.Component {
             >
               <FormattedMessage id="ui-checkout.checkout.notes" />
             </Button>}
-          { stripes.hasAnyPerm('ui-users.loans.add-patron-info,ui-users.loans-add-info.create') && !isVirtualUser && // stripes.hasAnyPerm('ui-users.loans.add-patron-info,ui-users.loans-add-info.create')
+          { stripes.hasAnyPerm('ui-users.loans.add-patron-info,ui-users.loans-add-info.create') && !isVirtualUser &&
             <Button
               data-test-add-patron-info
               buttonStyle="dropdownItem"

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -354,7 +354,7 @@ class ViewItem extends React.Component {
             >
               <FormattedMessage id="ui-checkout.loanPolicy" />
             </Button>}
-          { stripes.hasPerm('ui-users.loans.change-due-date') &&
+          { stripes.hasAnyPerm('ui-users.loans.change-due-date,ui-users.loans-due-date.edit') &&
             <Button
               data-test-date-picker
               buttonStyle="dropdownItem"
@@ -370,7 +370,7 @@ class ViewItem extends React.Component {
             >
               <FormattedMessage id="ui-checkout.checkout.notes" />
             </Button>}
-          { stripes.hasPerm('ui-users.loans.add-patron-info') && !isVirtualUser &&
+          { stripes.hasAnyPerm('ui-users.loans.add-patron-info,ui-users.loans-add-info.create') && !isVirtualUser && // stripes.hasAnyPerm('ui-users.loans.add-patron-info,ui-users.loans-add-info.create')
             <Button
               data-test-add-patron-info
               buttonStyle="dropdownItem"
@@ -378,7 +378,7 @@ class ViewItem extends React.Component {
             >
               <FormattedMessage id="ui-checkout.checkout.addInfo.patronInfo.button" />
             </Button>}
-          { stripes.hasPerm('ui-users.loans.add-staff-info') && !isVirtualUser &&
+          { stripes.hasAnyPerm('ui-users.loans.add-staff-info,ui-users.loans-add-info.create') && !isVirtualUser &&
             <Button
               data-test-add-staff-info
               buttonStyle="dropdownItem"

--- a/src/components/ViewItem/ViewItem.test.js
+++ b/src/components/ViewItem/ViewItem.test.js
@@ -52,6 +52,7 @@ const basicProps = {
   stripes: {
     connect: jest.fn(Component => Component),
     hasPerm: () => true,
+    hasAnyPerm: () => true,
   },
   patron: {
     id: 'patronId',

--- a/test/jest/__mock__/stripes.mock.js
+++ b/test/jest/__mock__/stripes.mock.js
@@ -2,6 +2,7 @@ import { noop } from 'lodash';
 
 const buildStripes = (otherProperties = {}) => ({
   hasPerm: noop,
+  hasAnyPerm: noop,
   hasInterface: noop,
   clone: noop,
   logger: { log: noop },

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -25,4 +25,5 @@ jest.mock('@folio/stripes/core', () => ({
     </div>
   )),
   IfPermission: jest.fn(({ children }) => <div>{children}</div>),
+  IfAnyPermission: jest.fn(({ children }) => <div>{children}</div>),
 }));


### PR DESCRIPTION
## Purpose
[UICHKOUT-927](https://folio-org.atlassian.net/browse/UICHKOUT-927) - Update permission checks of ui-users

## Approach
Several permissions of module ui-users have been updated in the scope of [UIU-3214](https://folio-org.atlassian.net/browse/UIU-3214)
ui-checkout module leverages various ui-users permissions in order to conditionally render several buttons, menu items…
Below is the list, where some refactor is needed for the permission checks-

[ui-checkout/src/components/ViewItem/ViewItem.js at ed73f74a2fadac70e0b321f7d9f491cf5de9e047 · folio-org/ui-checkout](https://github.com/folio-org/ui-checkout/blob/ed73f74a2fadac70e0b321f7d9f491cf5de9e047/src/components/ViewItem/ViewItem.js#L373) 

[ui-checkout/src/components/ViewItem/ViewItem.js at ed73f74a2fadac70e0b321f7d9f491cf5de9e047 · folio-org/ui-checkout](https://github.com/folio-org/ui-checkout/blob/ed73f74a2fadac70e0b321f7d9f491cf5de9e047/src/components/ViewItem/ViewItem.js#L381) 

[ui-checkout/src/components/ViewItem/ViewItem.js at ed73f74a2fadac70e0b321f7d9f491cf5de9e047 · folio-org/ui-checkout](https://github.com/folio-org/ui-checkout/blob/ed73f74a2fadac70e0b321f7d9f491cf5de9e047/src/components/ViewItem/ViewItem.js#L357) 

[ui-checkout/src/components/PatronBlock/PatronBlockModal.js at ed73f74a2fadac70e0b321f7d9f491cf5de9e047 · folio-org/ui-checkout](https://github.com/folio-org/ui-checkout/blob/ed73f74a2fadac70e0b321f7d9f491cf5de9e047/src/components/PatronBlock/PatronBlockModal.js#L45) 

[ui-checkout/src/components/ErrorModal/ErrorModal.js at ed73f74a2fadac70e0b321f7d9f491cf5de9e047 · folio-org/ui-checkout](https://github.com/folio-org/ui-checkout/blob/ed73f74a2fadac70e0b321f7d9f491cf5de9e047/src/components/ErrorModal/ErrorModal.js#L109) 

[ui-checkout/src/components/ErrorModal/ErrorModal.test.js at ed73f74a2fadac70e0b321f7d9f491cf5de9e047 · folio-org/ui-checkout](https://github.com/folio-org/ui-checkout/blob/ed73f74a2fadac70e0b321f7d9f491cf5de9e047/src/components/ErrorModal/ErrorModal.test.js#L25) 

Leverage “hasAnyPerm” and “IfAnyPermission” utilities from stripes-core in order to pick either the old permission name or updated/new permission name.
The above two utilities have been recently introduced in the scope of [STCOR-910](https://folio-org.atlassian.net/browse/STCOR-910)

## Refs
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UICHKOUT-771
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
