### PR TITLE
UICHKOUT-930: Update permission after mod-patron-blocks permission changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-checkout
 
 ## [11.1.0] In progress
+* Update permission after mod-patron-blocks permission changes. Refs UICHKOUT-930.
 
 ## [11.0.1](https://github.com/folio-org/ui-checkout/tree/v11.0.1) (2024-11-22)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v11.0.0...v11.0.1)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
           "proxiesfor.collection.get",
           "accounts.collection.get",
           "manualblocks.collection.get",
-          "automated-patron-blocks.collection.get",
+          "patron-blocks.automated-patron-blocks.collection.get",
           "module.checkout.enabled",
           "inventory.items.collection.get",
           "circulation.check-out-by-barcode.post",

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -97,7 +97,7 @@ class CheckOut extends React.Component {
       records: 'automatedPatronBlocks',
       path: 'automated-patron-blocks/%{activeRecord.patronId}',
       params: { limit: MAX_RECORDS },
-      permissionsRequired: 'automated-patron-blocks.collection.get',
+      permissionsRequired: 'patron-blocks.automated-patron-blocks.collection.get',
       accumulate: true,
       abortOnUnmount: true,
     },


### PR DESCRIPTION
## Purpose
Update permission after mod-patron-blocks permission changes

## Refs
https://issues.folio.org/browse/UICHKOUT-930