### PR TITLE
UICHKOUT-941 omit trailing whitespace from getFullName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * React v19: refactor away from default props for functional components. Refs UICHKOUT-909.
 * Fix accessibility issues. Refs UICHKOUT-933.
 * *BREAKING* Display user pronouns at check out. Refs UICHKOUT-932.
+* Omit trailing whitespace when formatting names. Refs UICHKOUT-941.
 
 ## [11.0.2] (https://github.com/folio-org/ui-checkout/tree/v11.0.2) (2024-11-30)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v11.0.1...v11.0.2)

--- a/src/components/UserDetail/UserDetail.css
+++ b/src/components/UserDetail/UserDetail.css
@@ -14,10 +14,6 @@
   margin-right: 10px;
 }
 
-.fullName {
-  margin-right: 1px;
-}
-
 .userPlaceholder {
   width: 60px;
   height: 60px;

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -79,7 +79,7 @@ class UserDetail extends React.Component {
   getUserValue = (user) => {
     const { ariaLabel } = this.props;
     const path = `/users/view/${user.id}`;
-    const pronouns = getFormattedPronouns(user);
+    const pronouns = getFormattedPronouns(user, true);
 
     return (
       <span>
@@ -88,10 +88,7 @@ class UserDetail extends React.Component {
             aria-label={ariaLabel}
             to={path}
           >
-            <strong
-              data-test-check-out-patron-full-name
-              className={css.fullName}
-            >
+            <strong data-test-check-out-patron-full-name>
               {getFullName(user)}
             </strong>
           </Link>

--- a/src/util.js
+++ b/src/util.js
@@ -35,10 +35,10 @@ export function getFullName(user) {
   return [user?.personal?.lastName, parts.filter(Boolean).join(' ')].filter(Boolean).join(', ');
 }
 
-export function getFormattedPronouns(user) {
+export function getFormattedPronouns(user, withPrefixSpace = false) {
   const pronouns = user?.personal?.pronouns;
 
-  return pronouns ? `(${pronouns})` : undefined;
+  return pronouns ? `${withPrefixSpace ? ' ' : ''}(${pronouns})` : undefined;
 }
 
 export function getCheckoutSettings(checkoutSettings) {

--- a/src/util.js
+++ b/src/util.js
@@ -19,8 +19,20 @@ import {
   DCB_USER_LASTNAME,
 } from './constants';
 
+/**
+ * getFullName
+ * Format a name like "Last, First Middle" or "Last, Preferred Middle" or
+ * "Last, First" or ... you get the idea.
+ * @param {*} user
+ * @returns {string}
+ */
 export function getFullName(user) {
-  return `${user?.personal?.lastName || ''}, ${user?.personal?.preferredFirstName || user?.personal?.firstName || ''} ${user?.personal?.middleName || ''}`;
+  const parts = [
+    user?.personal?.preferredFirstName ? user?.personal?.preferredFirstName : user?.personal?.firstName,
+    user?.personal?.middleName,
+  ];
+
+  return [user?.personal?.lastName, parts.filter(Boolean).join(' ')].filter(Boolean).join(', ');
 }
 
 export function getFormattedPronouns(user) {

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -47,23 +47,23 @@ describe('util', () => {
   const { OPEN_AWAITING_PICKUP } = OPEN_REQUEST_STATUSES;
 
   describe('getFullName', () => {
-    it('should not return user personal data', () => {
-      expect(getFullName({})).toEqual(',  ');
+    it('handles empty personal data', () => {
+      expect(getFullName({})).toEqual('');
     });
 
-    it('should return last name', () => {
+    it('handles { last }', () => {
       expect(getFullName({
         personal: {
           lastName,
         },
-      })).toEqual('LastName,  ');
+      })).toEqual('LastName');
     });
 
-    it('should return last name and first name', () => {
-      expect(getFullName(user)).toEqual('LastName, FirstName ');
+    it('handles {last, first}', () => {
+      expect(getFullName(user)).toEqual('LastName, FirstName');
     });
 
-    it('should return last name, first name and middle name', () => {
+    it('handles { last, first, middle }', () => {
       expect(getFullName({
         personal: {
           ...personal,
@@ -72,7 +72,7 @@ describe('util', () => {
       })).toEqual('LastName, FirstName MiddleName');
     });
 
-    it('should return last name, preferred first name and middle name', () => {
+    it('handles preferred', () => {
       const preferredFirstName = 'PreferredFirstName';
 
       expect(getFullName({
@@ -84,7 +84,7 @@ describe('util', () => {
       })).toEqual('LastName, PreferredFirstName MiddleName');
     });
 
-    it('should handle empty preferred first name', () => {
+    it('handles empty preferred value', () => {
       const preferredFirstName = '';
 
       expect(getFullName({


### PR DESCRIPTION
Previously, `getFullName()` would include trailing whitespace if the given object did not include a `personal.middleName` property. Now, all output is trimmed.

Refs [UICHKOUT-941](https://folio-org.atlassian.net/browse/UICHKOUT-941)
