### PR TITLE
UICHKOUT-948: Actions for check out item don't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add correct aria-label attribute to "Patron look-up" button. Refs UICHKOUT-934.
 * Implement support for fields without information. Refs UICHKOUT-945.
 * Check out items using new endpoint from mod-circulation-bff. Refs UICHKOUT-946.
+* Use `history.push` instead of `mutator.query` updating. Refs UICHKOUT-948.
 
 ## [11.0.2] (https://github.com/folio-org/ui-checkout/tree/v11.0.2) (2024-11-30)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v11.0.1...v11.0.2)

--- a/src/CheckOut.js
+++ b/src/CheckOut.js
@@ -54,7 +54,6 @@ class CheckOut extends React.Component {
     // checking out as the sponsor (selPatron and patron are different) or
     // checkout out as self (selPatron and patron are the same)
     selPatron: { initialValue: {} },
-    query: { initialValue: {} },
     scannedItems: { initialValue: [] },
     patronBlockOverriddenInfo: { initialValue: {} },
     checkoutSettings: {

--- a/src/components/ViewItem/ViewItem.js
+++ b/src/components/ViewItem/ViewItem.js
@@ -83,6 +83,9 @@ class ViewItem extends React.Component {
     }).isRequired,
     addPatronOrStaffInfo: PropTypes.func.isRequired,
     intl: PropTypes.object,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   constructor(props) {
@@ -260,9 +263,7 @@ class ViewItem extends React.Component {
       e.preventDefault();
     }
 
-    this.props.parentMutator.query.update({
-      _path: `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`,
-    });
+    this.props.history.push(`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`);
   }
 
   showLoanDetails(loan, e) {
@@ -270,9 +271,7 @@ class ViewItem extends React.Component {
       e.preventDefault();
     }
 
-    this.props.parentMutator.query.update({
-      _path: `/users/view/${loan.userId}?layer=loan&loan=${loan.id}`,
-    });
+    this.props.history.push(`/users/view/${loan.userId}?layer=loan&loan=${loan.id}`);
   }
 
   showLoanPolicy(loan, e) {
@@ -280,9 +279,7 @@ class ViewItem extends React.Component {
       e.preventDefault();
     }
 
-    this.props.parentMutator.query.update({
-      _path: `/settings/circulation/loan-policies/${loan.loanPolicyId}`,
-    });
+    this.props.history.push(`/settings/circulation/loan-policies/${loan.loanPolicyId}`);
   }
 
   showCheckoutNotes(loan) {

--- a/src/components/ViewItem/ViewItem.test.js
+++ b/src/components/ViewItem/ViewItem.test.js
@@ -58,9 +58,6 @@ const basicProps = {
     id: 'patronId',
   },
   parentMutator: {
-    query: {
-      update: jest.fn(),
-    },
     scannedItems: {
       replace: jest.fn(),
     },
@@ -78,6 +75,9 @@ const basicProps = {
     overriddenItemsList: ['itemBarcode'],
   },
   intl: {},
+  history: {
+    push: jest.fn(),
+  },
 };
 const basicPropsWithDCBItem = {
   ...basicProps,
@@ -239,15 +239,13 @@ describe('ViewItem', () => {
         expect(itemDetailsLabel).toBeVisible();
       });
 
-      it('should trigger "query.update" for item with correct arguments', () => {
+      it('should trigger "history.push" for item with correct arguments', () => {
         const itemDetailsButton = screen.getByText(labelIds.itemDetailsButton);
-        const expectedArg = {
-          _path: `/inventory/view/${basicProps.scannedItems[0].item.instanceId}/${basicProps.scannedItems[0].item.holdingsRecordId}/${basicProps.scannedItems[0].itemId}`,
-        };
+        const expectedArg = `/inventory/view/${basicProps.scannedItems[0].item.instanceId}/${basicProps.scannedItems[0].item.holdingsRecordId}/${basicProps.scannedItems[0].itemId}`;
 
         fireEvent.click(itemDetailsButton);
 
-        expect(basicProps.parentMutator.query.update).toHaveBeenCalledWith(expectedArg);
+        expect(basicProps.history.push).toHaveBeenCalledWith(expectedArg);
       });
 
       it('should render loan details button label', () => {
@@ -256,15 +254,13 @@ describe('ViewItem', () => {
         expect(loanDetailsLabel).toBeVisible();
       });
 
-      it('should trigger "query.update" for loan details with correct arguments', () => {
+      it('should trigger "history.push" for loan details with correct arguments', () => {
         const loanDetailsButton = screen.getByText(labelIds.loanDetailsButton);
-        const expectedArg = {
-          _path: `/users/view/${basicProps.scannedItems[0].userId}?layer=loan&loan=${basicProps.scannedItems[0].id}`,
-        };
+        const expectedArg = `/users/view/${basicProps.scannedItems[0].userId}?layer=loan&loan=${basicProps.scannedItems[0].id}`;
 
         fireEvent.click(loanDetailsButton);
 
-        expect(basicProps.parentMutator.query.update).toHaveBeenCalledWith(expectedArg);
+        expect(basicProps.history.push).toHaveBeenCalledWith(expectedArg);
       });
 
       it('should render loan policy button label', () => {
@@ -273,15 +269,13 @@ describe('ViewItem', () => {
         expect(loanPolicyLabel).toBeVisible();
       });
 
-      it('should trigger "query.update" for loan policy with correct arguments', () => {
+      it('should trigger "history.push" for loan policy with correct arguments', () => {
         const loanPolicyButton = screen.getByText(labelIds.loanPolicyButton);
-        const expectedArg = {
-          _path: `/settings/circulation/loan-policies/${basicProps.scannedItems[0].loanPolicyId}`,
-        };
+        const expectedArg = `/settings/circulation/loan-policies/${basicProps.scannedItems[0].loanPolicyId}`;
 
         fireEvent.click(loanPolicyButton);
 
-        expect(basicProps.parentMutator.query.update).toHaveBeenCalledWith(expectedArg);
+        expect(basicProps.history.push).toHaveBeenCalledWith(expectedArg);
       });
 
       it('should render change due date button label', () => {


### PR DESCRIPTION
## Purpose
By some reason `mutator.query.update` does not have any impact on current application url.
In the scope of this PR I use `history.push` instead of `mutator.query.update`.

## Refs
[UICHKOUT-948](https://folio-org.atlassian.net/browse/UICHKOUT-948)