### PR TITLE
UICHKOUT-956: Modal with error appears if user has "Check out: All permissions" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Replace moment with day.js. Refs UICHKOUT-949.
 * Remove failed tests after packages updating. Refs UICHKOUT-955.
+* Add missed "users.configurations.item.get" permission. Refs UICHKOUT-956.
 
 ## [12.0.0] (https://github.com/folio-org/ui-checkout/tree/v12.0.0) (2025-03-14)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v11.0.3...v12.0.0)

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
           "circulation-storage.loan-policies.collection.get",
           "circulation.end-patron-action-session.post",
           "configuration.entries.collection.get",
-          "note.links.collection.get"
+          "note.links.collection.get",
+          "users.configurations.item.get"
         ]
       },
       {


### PR DESCRIPTION
## Purpose
Add missed subpermission.

## Refs
[UICHKOUT-956](https://folio-org.atlassian.net/browse/UICHKOUT-956)