### PR TITLE
[UICHKOUT-967] Guard against multiple invocations of componentDidMount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Replace moment with day.js. Refs UICHKOUT-949.
 * Reduce count of eslint errors after update eslint-config-stripes. Refs UICHKOUT-953.
 * Fix Loan details link in Check out app. Refs UICHKOUT-960.
+* Guard against multiple invocations of `componentDidMount`. Refs UICHKOUT-474.
 
 ## [12.0.1] (https://github.com/folio-org/ui-checkout/tree/v12.0.1) (2025-04-11)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v12.0.1...v12.0.1)

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -85,9 +85,24 @@ class ModalManager extends React.Component {
         exec: () => this.setState({ showMultipieceModal: true }),
       }
     ];
+    this.componentDidMount_has_run = false;
   }
 
   componentDidMount() {
+    if (this.componentDidMount_has_run) {
+      // In React v18.x, when Strict Mode is turned on in development,
+      // all componentDidMount methods are run twice, to help you
+      // detect when you inadvertently do non-idempotent things such
+      // as, well, checking out items. But the whole way this module
+      // works depends on doing checkout (in the execSteps method) as
+      // a side-effect of mounting the component. We should fix that,
+      // and will do so in UICHKOUT-968. But until we do, we make
+      // development possible by explicitly guarding to ensure that
+      // this method only runs once.
+      return;
+    }
+
+    this.componentDidMount_has_run = true;
     if (this.state.checkoutNotesMode) {
       this.setState({ showCheckoutNoteModal: true });
     } else {


### PR DESCRIPTION
When running in dev mode — and not in production — React 18 will deliberately run all `componentDidMount` methods twice. It does this to help you find places where you are inadvertently doing non-idempotent things, such as, well, checking out items. See https://react.dev/reference/react/Component#componentdidmount

The proper fix is to change the whole approach of ui-checkout so it doesn’t rely on side-effects of mounting a component. That would be a complicated job and I don’t understand the logic of the module well enough to confident I was doing that work right.

This commit simply adds guard code to the `componentDidMount` method so that it only runs once. That makes no difference to how the code runs in production, but makes it possible to do development.
