### PR TITLE
UICHKOUT-975 proptypes correction

### DIFF
--- a/src/components/ItemForm/ItemForm.js
+++ b/src/components/ItemForm/ItemForm.js
@@ -60,7 +60,7 @@ class ItemForm extends React.Component {
     onNeedMoreData: PropTypes.func.isRequired,
     barcode: PropTypes.oneOfType([
       PropTypes.oneOf([null, PropTypes.string])
-    ]).isRequired,
+    ]),
     pagingOffset: PropTypes.number.isRequired,
   };
 


### PR DESCRIPTION
`barcode` may not be defined when the app first renders, and therefore cannot be required.

