### PR TITLE
UICHKOUT-1004: Fix @folio/circulation optional dependency version to >=12.0.0 and correct import path for stripes.mock in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkout
 
+## [13.1.0] IN_PROGRESS
+
+* Fix `@folio/circulation` optional dependency version to `>=12.0.0` and correct import path for `stripes.mock` in tests. Refs UICHKOUT-1004.
+
 ## [13.0.1] (https://github.com/folio-org/ui-checkout/tree/v13.0.1) (2026-05-06)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v13.0.0...v13.0.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkout",
-  "version": "13.0.1",
+  "version": "13.1.0",
   "description": "Item Check-out",
   "repository": "folio-org/ui-checkout",
   "publishConfig": {
@@ -165,7 +165,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/circulation": "^12.0.0",
+    "@folio/circulation": ">=12.0.0",
     "@folio/plugin-create-inventory-records": "^7.0.0",
     "@folio/plugin-find-user": "^8.0.0"
   }

--- a/src/components/ItemForm/ItemForm.test.js
+++ b/src/components/ItemForm/ItemForm.test.js
@@ -6,7 +6,7 @@ import {
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
 
-import buildStripes from '@folio/circulation/test/jest/__mock__/stripes.mock';
+import buildStripes from '../../../test/jest/__mock__/stripes.mock';
 
 import ItemForm, {
   shouldSkipFocus,


### PR DESCRIPTION
## Purpose
Fix @folio/circulation optional dependency version to >=12.0.0 and correct import path for stripes.mock in tests

## Approach
Our project relies exclusively on static media assets ( https://github.com/folio-org/ui-circulation/tree/master/sound ); therefore, we can support any version of the @folio/circulation module, as these files remain unaffected by logic changes.

# Refs
https://issues.folio.org/browse/UICHKOUT-1004