### PR TITLE
UICHKOUT-959: Fix Open loans counter not updating after checkout via circulation-bff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [13.1.0] IN_PROGRESS
 
 * Fix `@folio/circulation` optional dependency version to `>=12.0.0` and correct import path for `stripes.mock` in tests. Refs UICHKOUT-1004.
+* Fix Open loans counter not updating after checkout via circulation-bff. Refs UICHKOUT-959.
 
 ## [13.0.1] (https://github.com/folio-org/ui-checkout/tree/v13.0.1) (2026-05-06)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v13.0.0...v13.0.1)

--- a/src/components/UserDetail/UserDetail.js
+++ b/src/components/UserDetail/UserDetail.js
@@ -40,6 +40,7 @@ class UserDetail extends React.Component {
     openLoansCount: {
       type: 'okapi',
       path: 'circulation/loans?query=(userId==!{user.id} and status.name<>Closed)&limit=1',
+      shouldRefresh: (resource, action, refresh) => refresh || action.meta.path === 'circulation-bff',
     },
     openAccounts: {
       type: 'okapi',


### PR DESCRIPTION
## Purpose
Fix Open loans counter not updating after checkout via circulation-bff

# Refs
https://issues.folio.org/browse/UICHKOUT-959