### PR TITLE
UICHKOUT-1012: Prevent displaying custom fields in `ViewCustomFieldsRecord` when `checkoutSettings` is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `@folio/circulation` optional dependency version to `>=12.0.0` and correct import path for `stripes.mock` in tests. Refs UICHKOUT-1004.
 * Fix Open request counter not updating after checkout via `circulation-bff`. Refs UICHKOUT-1006.
+* Prevent displaying custom fields in `ViewCustomFieldsRecord` when `checkoutSettings` is empty. Fixes UICHKOUT-1012.
 
 ## [13.0.2] (https://github.com/folio-org/ui-checkout/tree/v13.0.2) (2026-05-26)
 [Full Changelog](https://github.com/folio-org/ui-checkout/compare/v13.0.1...v13.0.2)

--- a/src/components/ViewPatron/ViewPatron.js
+++ b/src/components/ViewPatron/ViewPatron.js
@@ -65,11 +65,18 @@ class ViewPatron extends React.Component {
       checkoutSettings,
       stripes,
     } = this.props;
-    const allowedCustomFieldRefIds = getCheckoutSettings(checkoutSettings)?.allowedCustomFieldRefIds;
 
     if (!stripes.hasInterface('custom-fields')) {
       return null;
     }
+
+    const parsedSettings = getCheckoutSettings(checkoutSettings);
+
+    if (!parsedSettings) {
+      return null;
+    }
+
+    const allowedCustomFieldRefIds = parsedSettings.allowedCustomFieldRefIds;
 
     return (
       <ViewCustomFieldsRecord

--- a/src/components/ViewPatron/ViewPatron.test.js
+++ b/src/components/ViewPatron/ViewPatron.test.js
@@ -418,13 +418,8 @@ describe('ViewPatron', () => {
         );
       });
 
-      it('should render "ViewCustomFieldsRecord" with undefined allowedRefIds', () => {
-        expect(ViewCustomFieldsRecord).toHaveBeenCalledWith(
-          expect.objectContaining({
-            allowedRefIds: undefined,
-          }),
-          {}
-        );
+      it('should not render "ViewCustomFieldsRecord"', () => {
+        expect(ViewCustomFieldsRecord).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UICHKOUT-771: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
Custom fields shouldn't be visible in the checkout app when  `checkoutSettings` is empty.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
https://folio-org.atlassian.net/browse/UICHKOUT-1012
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UICHKOUT-771
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
